### PR TITLE
Remove En1545Parsed.getTimeStampString, and clean up En1545TransitData.info

### DIFF
--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/en1545/En1545FixedInteger.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/en1545/En1545FixedInteger.kt
@@ -42,6 +42,7 @@ class En1545FixedInteger(private val mName: String, private val mLen: Int) : En1
 
         fun dateName(base: String) = "${base}Date"
         fun datePackedName(base: String) = "${base}DatePacked"
+        fun dateBCDName(base: String) = "${base}DateBCD"
 
         fun timeName(base: String) = "${base}Time"
 
@@ -102,7 +103,7 @@ class En1545FixedInteger(private val mName: String, private val mLen: Int) : En1
             return if (sec == 0) null else getEpoch(tz).daySecond(sec / 86400, sec % 86400)
         }
 
-        fun parseBCDDate(date: Int): Timestamp {
+        fun parseDateBCD(date: Int): Timestamp {
             return Daystamp(NumberUtils.convertBCDtoInteger(date shr 16),
                     NumberUtils.convertBCDtoInteger((date shr 8) and 0xff) - 1,
                     NumberUtils.convertBCDtoInteger(date and 0xff))
@@ -110,10 +111,10 @@ class En1545FixedInteger(private val mName: String, private val mLen: Int) : En1
 
         fun date(name: String) = En1545FixedInteger(dateName(name), 14)
         fun datePacked(name: String) = En1545FixedInteger(datePackedName(name), 14)
+        fun dateBCD(name: String) = En1545FixedInteger(dateBCDName(name), 32)
         fun time(name: String) = En1545FixedInteger(timeName(name), 11)
         fun timePacked16(name: String) = En1545FixedInteger(timePacked16Name(name), 16)
         fun timePacked11Local(name: String) = En1545FixedInteger(timePacked11LocalName(name), 11)
-        fun BCDdate(name: String) = En1545FixedInteger(name, 32)
         fun dateTime(name: String) = En1545FixedInteger(dateTimeName(name), 30)
         fun dateTimeLocal(name: String) = En1545FixedInteger(dateTimeLocalName(name), 30)
         fun timeLocal(name: String) = En1545FixedInteger(timeLocalName(name), 11)

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/en1545/En1545Parsed.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/en1545/En1545Parsed.kt
@@ -127,18 +127,11 @@ class En1545Parsed(private val map: MutableMap<String, En1545Value> = mutableMap
         if (contains(En1545FixedInteger.datePackedName(name)))
             return En1545FixedInteger.parseDatePacked(
                     getIntOrZero(En1545FixedInteger.datePackedName(name)))
+        if (contains(En1545FixedInteger.dateBCDName(name)))
+            return En1545FixedInteger.parseDateBCD(
+                    getIntOrZero(En1545FixedInteger.dateBCDName(name)))
         return null
         // TODO: any need to support time-only cases?
-    }
-
-    fun getTimeStampString(name: String, tz: MetroTimeZone): String? {
-        val timeFlag = getTimeStamp(name, tz)
-        if (timeFlag == null) {
-            val value = getInt(En1545FixedInteger.timeName(name)) ?: getInt(En1545FixedInteger.timeLocalName(name))
-            ?: return null
-            return dig2(value / 60) + ":" + dig2(value % 60)
-        }
-        return timeFlag.format().toString()
     }
 
     fun contains(name: String, path: String = ""): Boolean {

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/en1545/En1545TransitData.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/en1545/En1545TransitData.kt
@@ -39,12 +39,12 @@ abstract class En1545TransitData : TransitData {
                         mTicketEnvParsed.getIntOrZero(ENV_NETWORK_ID).toString(16)))
 
             mTicketEnvParsed.getTimeStamp(ENV_APPLICATION_VALIDITY_END, tz)?.let {
-                li.add(ListItem(R.string.expiry_date, TimestampFormatter.longDateFormat(it)))
+                li.add(ListItem(R.string.expiry_date, it.format()))
             }
 
             if (!Preferences.hideCardNumbers && !Preferences.obfuscateTripDates)
                 mTicketEnvParsed.getTimeStamp(HOLDER_BIRTH_DATE, tz)?.let {
-                    li.add(ListItem(R.string.date_of_birth, TimestampFormatter.longDateFormat(it)))
+                    li.add(ListItem(R.string.date_of_birth, it.format()))
                 }
 
             if (mTicketEnvParsed.getIntOrZero(ENV_APPLICATION_ISSUER_ID) != 0)
@@ -52,11 +52,11 @@ abstract class En1545TransitData : TransitData {
                         lookup.getAgencyName(mTicketEnvParsed.getIntOrZero(ENV_APPLICATION_ISSUER_ID), false)))
 
             mTicketEnvParsed.getTimeStamp(ENV_APPLICATION_ISSUE, tz)?.let {
-                li.add(ListItem(R.string.issue_date, TimestampFormatter.longDateFormat(it)))
+                li.add(ListItem(R.string.issue_date, it.format()))
             }
 
             mTicketEnvParsed.getTimeStamp(HOLDER_PROFILE, tz)?.let {
-                li.add(ListItem(R.string.en1545_card_expiry_date_profile, TimestampFormatter.longDateFormat(it)))
+                li.add(ListItem(R.string.en1545_card_expiry_date_profile, it.format()))
             }
 
             if (!Preferences.hideCardNumbers && !Preferences.obfuscateTripDates)

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/intercode/IntercodeTransitData.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/intercode/IntercodeTransitData.kt
@@ -22,7 +22,6 @@ package au.id.micolous.metrodroid.transit.intercode
 import au.id.micolous.metrodroid.card.CardType
 import au.id.micolous.metrodroid.card.calypso.CalypsoApplication
 import au.id.micolous.metrodroid.card.calypso.CalypsoCardTransitFactory
-import au.id.micolous.metrodroid.multi.Localizer
 import au.id.micolous.metrodroid.multi.Parcelize
 import au.id.micolous.metrodroid.multi.R
 import au.id.micolous.metrodroid.transit.CardInfo
@@ -46,8 +45,7 @@ class IntercodeTransitData (val capsule: Calypso1545TransitDataCapsule) : Calyps
                         En1545FixedInteger.dateName(En1545TransitData.ENV_APPLICATION_VALIDITY_END),
                         En1545TransitData.ENV_AUTHENTICATOR,
                         En1545FixedInteger.dateName(En1545TransitData.HOLDER_PROFILE),
-                        En1545TransitData.HOLDER_BIRTH_DATE,
-                        En1545TransitData.HOLDER_POSTAL_CODE,
+                        En1545FixedInteger.dateBCDName(En1545TransitData.HOLDER_BIRTH_DATE),
                         HOLDER_CARD_TYPE))
 
     override val lookup get() = getLookup(networkId)
@@ -94,7 +92,7 @@ class IntercodeTransitData (val capsule: Calypso1545TransitDataCapsule) : Calyps
                                 En1545FixedString("HolderForename", 85)
                         ),
                         En1545Bitmap(
-                                En1545FixedInteger(En1545TransitData.HOLDER_BIRTH_DATE, 32),
+                                En1545FixedInteger.dateBCD(En1545TransitData.HOLDER_BIRTH_DATE),
                                 En1545FixedString("HolderBirthPlace", 115)
                         ),
                         En1545FixedString("HolderBirthName", 85),

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/lisboaviva/LisboaVivaTransitData.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/lisboaviva/LisboaVivaTransitData.kt
@@ -79,7 +79,7 @@ class LisboaVivaTransitData (private val capsule: Calypso1545TransitDataCapsule,
                 En1545FixedInteger.date(En1545TransitData.ENV_APPLICATION_ISSUE),
                 En1545FixedInteger.date(En1545TransitData.ENV_APPLICATION_VALIDITY_END),
                 En1545FixedInteger(En1545TransitData.ENV_UNKNOWN_C, 15),
-                En1545FixedInteger(En1545TransitData.HOLDER_BIRTH_DATE, 32),
+                En1545FixedInteger.dateBCD(En1545TransitData.HOLDER_BIRTH_DATE),
                 En1545FixedHex(En1545TransitData.ENV_UNKNOWN_D, 95)
         )
 

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/mobib/MobibTransitData.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/mobib/MobibTransitData.kt
@@ -111,10 +111,10 @@ class MobibTransitData(
                         En1545FixedInteger(En1545TransitData.ENV_UNKNOWN_B, 9),
                         En1545FixedInteger.date(En1545TransitData.ENV_APPLICATION_VALIDITY_END),
                         En1545FixedInteger(En1545TransitData.ENV_UNKNOWN_C, 6),
-                        En1545FixedInteger(En1545TransitData.HOLDER_BIRTH_DATE, 32),
+                        En1545FixedInteger.dateBCD(En1545TransitData.HOLDER_BIRTH_DATE),
                         En1545FixedHex(En1545TransitData.ENV_CARD_SERIAL, 76),
                         En1545FixedInteger(En1545TransitData.ENV_UNKNOWN_D, 5),
-                        En1545FixedInteger(En1545TransitData.HOLDER_POSTAL_CODE, 14),
+                        En1545FixedInteger(En1545TransitData.HOLDER_INT_POSTAL_CODE, 14),
                         En1545FixedHex(En1545TransitData.ENV_UNKNOWN_E, 34)
                 )
                 else -> En1545Container(
@@ -124,10 +124,10 @@ class MobibTransitData(
                         En1545FixedInteger(En1545TransitData.ENV_UNKNOWN_B, 5),
                         En1545FixedInteger.date(En1545TransitData.ENV_APPLICATION_VALIDITY_END),
                         En1545FixedInteger(En1545TransitData.ENV_UNKNOWN_C, 10),
-                        En1545FixedInteger(En1545TransitData.HOLDER_BIRTH_DATE, 32),
+                        En1545FixedInteger.dateBCD(En1545TransitData.HOLDER_BIRTH_DATE),
                         En1545FixedHex(En1545TransitData.ENV_CARD_SERIAL, 76),
                         En1545FixedInteger(En1545TransitData.ENV_UNKNOWN_D, 5),
-                        En1545FixedInteger(En1545TransitData.HOLDER_POSTAL_CODE, 14),
+                        En1545FixedInteger(En1545TransitData.HOLDER_INT_POSTAL_CODE, 14),
                         En1545FixedHex(En1545TransitData.ENV_UNKNOWN_E, 34)
                 )
         }

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/opus/OpusTransitData.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/opus/OpusTransitData.kt
@@ -72,7 +72,7 @@ class OpusTransitData (val capsule: Calypso1545TransitDataCapsule): Calypso1545T
                 En1545Bitmap(
                         En1545Container(
                                 En1545FixedInteger(En1545TransitData.HOLDER_UNKNOWN_A, 3),
-                                En1545FixedInteger.BCDdate(En1545TransitData.HOLDER_BIRTH_DATE),
+                                En1545FixedInteger.dateBCD(En1545TransitData.HOLDER_BIRTH_DATE),
                                 En1545FixedInteger(En1545TransitData.HOLDER_UNKNOWN_B, 13),
                                 En1545FixedInteger.date(En1545TransitData.HOLDER_PROFILE),
                                 En1545FixedInteger(En1545TransitData.HOLDER_UNKNOWN_C, 8)

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/ovc/OVChipTransitData.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/ovc/OVChipTransitData.kt
@@ -108,7 +108,7 @@ data class OVChipTransitData(
                             En1545Bitmap(
                                     En1545FixedHex("NeverSeen1", 8),
                                     En1545Container(
-                                            En1545FixedInteger(En1545TransitData.HOLDER_BIRTH_DATE, 32),
+                                            En1545FixedInteger.dateBCD(En1545TransitData.HOLDER_BIRTH_DATE),
                                             En1545FixedHex("EnvUnknown3", 32),
                                             En1545FixedInteger(AUTOCHARGE_ACTIVE, 3),
                                             En1545FixedInteger(AUTOCHARGE_LIMIT, 16),

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/pisa/PisaTransitData.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/pisa/PisaTransitData.kt
@@ -27,7 +27,6 @@ import au.id.micolous.metrodroid.multi.Parcelize
 import au.id.micolous.metrodroid.transit.CardInfo
 import au.id.micolous.metrodroid.transit.TransitIdentity
 import au.id.micolous.metrodroid.transit.en1545.*
-import au.id.micolous.metrodroid.ui.ListItem
 import au.id.micolous.metrodroid.util.ImmutableByteArray
 
 @Parcelize
@@ -64,7 +63,7 @@ data class PisaTransitData(val calypso: Calypso1545TransitDataCapsule) : Calypso
                 En1545FixedHex(ENV_UNKNOWN_A, 44),
                 En1545FixedInteger.date(ENV_APPLICATION_ISSUE),
                 En1545FixedInteger.date(ENV_APPLICATION_VALIDITY_END),
-                En1545FixedInteger(HOLDER_BIRTH_DATE, 32)
+                En1545FixedInteger.dateBCD(HOLDER_BIRTH_DATE)
                 // Remainder: zero-filled
         )
 

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/ravkav/RavKavTransitData.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/ravkav/RavKavTransitData.kt
@@ -80,7 +80,7 @@ class RavKavTransitData (val capsule: Calypso1545TransitDataCapsule): Calypso154
                 En1545FixedInteger.date(ENV_APPLICATION_ISSUE),
                 En1545FixedInteger.date(ENV_APPLICATION_VALIDITY_END),
                 En1545FixedInteger("PayMethod", 3),
-                En1545FixedInteger(HOLDER_BIRTH_DATE, 32),
+                En1545FixedInteger.dateBCD(HOLDER_BIRTH_DATE),
                 En1545FixedHex(ENV_UNKNOWN_B, 44),
                 En1545FixedInteger(HOLDER_ID_NUMBER, 30)
         )

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/ricaricami/RicaricaMiTransitData.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/ricaricami/RicaricaMiTransitData.kt
@@ -30,7 +30,6 @@ import au.id.micolous.metrodroid.transit.TransactionTrip
 import au.id.micolous.metrodroid.transit.TransactionTripAbstract
 import au.id.micolous.metrodroid.transit.TransitIdentity
 import au.id.micolous.metrodroid.transit.en1545.*
-import au.id.micolous.metrodroid.ui.HeaderListItem
 import au.id.micolous.metrodroid.util.ImmutableByteArray
 
 @Parcelize
@@ -73,7 +72,7 @@ data class RicaricaMiTransitData(private val mTrips: List<TransactionTripAbstrac
 
         private val BLOCK_1_0_FIELDS = En1545Container(
                 En1545FixedInteger(En1545TransitData.ENV_UNKNOWN_A, 9),
-                En1545FixedInteger.BCDdate(En1545TransitData.HOLDER_BIRTH_DATE),
+                En1545FixedInteger.dateBCD(En1545TransitData.HOLDER_BIRTH_DATE),
                 En1545FixedHex(En1545TransitData.ENV_UNKNOWN_B, 47),
                 En1545FixedInteger.date(En1545TransitData.ENV_APPLICATION_VALIDITY_END),
                 En1545FixedInteger(En1545TransitData.ENV_UNKNOWN_C, 26)


### PR DESCRIPTION
This is an alternative to #497.

* New `bcdDate` field naming for EN1545.

* Renames `En1545FixedInteger` methods `parseBCDDate` and `BCDdate` to `parseDateBCD` and `dateBCD` respectively for consistency (with `datePacked`, etc.)

* Hide holders' date of birth and postal code when hideCardNumbers or obfuscateTripDates are enabled (similar to `MobibTransitData` behaviour).

* Rename `HOLDER_POSTAL_CODE` to `HOLDER_INT_POSTAL_CODE` to clarify datatype.

  Presently, this is only used by Mobib (Belgium), which has 4 digit postal codes from 1000-9999, but may be an issue if other cards start using the field.

* Removes reference to `HOLDER_POSTAL_CODE` in `IntercodeTransitData` -- only Mobib uses it, and `MobibTransitData`, which is not based on the Intercode classes.

* Mark all `HOLDER_BIRTH_DATE` as `dateBCD` type.

I've tested this with Adelaide Metro, but this **doesn't** use the `HOLDER_BIRTH_DATE` field.

Testing this with a personalised Mobib, Lisboa Viva, Opus, OVC, Pisa, Rav-Kav or RicaricaMi would probably have the `HOLDER_BIRTH_DATE` field.