### PR TITLE
Add Greek spelling of Metrodroid

### DIFF
--- a/src/main/res/values-el/strings.xml
+++ b/src/main/res/values-el/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="app_name">Μετρόδροειδ</string>
     <string name="license">Άδειες</string>
     <string name="directions">Αγγίξτε μια κάρτα.</string>
     <string name="reading_card">Ανάγνωση κάρτας…</string>


### PR DESCRIPTION
There are essentially 3 ways of doing it

1. Keep it in English
2. Phonetically. Closest phonetically would be "Μετροντροιντ"
3. Go back to original "android" (human-like robot) word "ανδροειδ"
and replace "an" with "Metro" ("Μετρό").

This patch uses the third variant