### PR TITLE
Make TransitCurrencyTest run as unit test as well

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,6 @@ buildscript {
         lint_version = '26.2.1'
         support_version = '28.0.0'
         android_test_version = '1.2.0'
-        hamcrest_version = '1.3'
         build_version = '29.0.0'
         android_sdk_version = 29
         android_min_version = 16
@@ -90,8 +89,6 @@ dependencies {
     androidTestImplementation "androidx.test:rules:$android_test_version"
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     androidTestImplementation "androidx.test.ext:junit:1.1.1"
-    androidTestImplementation "org.hamcrest:hamcrest-core:$hamcrest_version"
-    androidTestImplementation "org.hamcrest:hamcrest-library:$hamcrest_version"
     testImplementation 'org.robolectric:robolectric:4.3'
 
     lintChecks project(':lintchecks')

--- a/jvmcli/build.gradle
+++ b/jvmcli/build.gradle
@@ -14,7 +14,6 @@ buildscript {
         lint_version = '26.2.1'
         support_version = '28.0.0'
         android_test_version = '1.1.0'
-        hamcrest_version = '1.3'
         build_version = '28.0.3'
         android_sdk_version = 28
         android_min_version = 16

--- a/src/androidTest/java/au/id/micolous/metrodroid/test/BaseInstrumentedTestPlatform.kt
+++ b/src/androidTest/java/au/id/micolous/metrodroid/test/BaseInstrumentedTestPlatform.kt
@@ -113,7 +113,7 @@ actual abstract class BaseInstrumentedTestPlatform {
         assertThat<String>(actualString, matcher)
     }
 
-    fun assertTtsMarkers(currencyCode: String, value: String, span: Spanned) {
+    fun assertTtsMarkers(currencyCode: String, value: String, fraction: String?, span: Spanned) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
             return
         }
@@ -125,5 +125,6 @@ actual abstract class BaseInstrumentedTestPlatform {
         val bundle = ttsSpans[0].args
         assertEquals(currencyCode, bundle.getString(TtsSpan.ARG_CURRENCY))
         assertEquals(value, bundle.getString(TtsSpan.ARG_INTEGER_PART))
+        assertEquals(fraction, bundle.getString(TtsSpan.ARG_FRACTIONAL_PART))
     }
 }

--- a/src/androidTest/java/au/id/micolous/metrodroid/test/BaseInstrumentedTestPlatform.kt
+++ b/src/androidTest/java/au/id/micolous/metrodroid/test/BaseInstrumentedTestPlatform.kt
@@ -31,8 +31,6 @@ import au.id.micolous.metrodroid.MetrodroidApplication
 import au.id.micolous.metrodroid.util.Preferences
 import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.runBlocking
-import org.hamcrest.Matcher
-import org.hamcrest.MatcherAssert.assertThat
 import org.junit.runner.RunWith
 import java.io.DataInputStream
 import java.io.InputStream

--- a/src/androidTest/java/au/id/micolous/metrodroid/test/BaseInstrumentedTestPlatform.kt
+++ b/src/androidTest/java/au/id/micolous/metrodroid/test/BaseInstrumentedTestPlatform.kt
@@ -101,30 +101,5 @@ actual abstract class BaseInstrumentedTestPlatform {
 
     actual fun listAsset(path: String) : List <String>? = context.assets.list(path)?.toList()
 
-    fun assertSpannedEquals(expected: String, actual: Spanned) {
-        // nbsp -> sp
-        val actualString = actual.toString().replace(' ', ' ')
-        assertEquals(expected, actualString)
-    }
-
-    fun assertSpannedThat(actual: Spanned, matcher: Matcher<in String>) {
-        // nbsp -> sp
-        val actualString = actual.toString().replace(' ', ' ')
-        assertThat<String>(actualString, matcher)
-    }
-
-    fun assertTtsMarkers(currencyCode: String, value: String, fraction: String?, span: Spanned) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-            return
-        }
-
-        val ttsSpans = span.getSpans(0, span.length, TtsSpan::class.java)
-        assertEquals(1, ttsSpans.size)
-
-        assertEquals(TtsSpan.TYPE_MONEY, ttsSpans[0].type)
-        val bundle = ttsSpans[0].args
-        assertEquals(currencyCode, bundle.getString(TtsSpan.ARG_CURRENCY))
-        assertEquals(value, bundle.getString(TtsSpan.ARG_INTEGER_PART))
-        assertEquals(fraction, bundle.getString(TtsSpan.ARG_FRACTIONAL_PART))
-    }
+    val isUnitTest get() = false
 }

--- a/src/androidTest/java/au/id/micolous/metrodroid/test/TransitCurrencyTest.kt
+++ b/src/androidTest/java/au/id/micolous/metrodroid/test/TransitCurrencyTest.kt
@@ -45,13 +45,25 @@ class TransitCurrencyTest : BaseInstrumentedTest() {
 
         val aud = TransitCurrency.AUD(1234).formatCurrencyString(true).spanned
         assertSpannedEquals("$12.34", aud)
-        assertTtsMarkers("AUD", "12.34", aud)
+        assertTtsMarkers("AUD", "12", "34", aud)
+
+        val aud00 = TransitCurrency.AUD(1200).formatCurrencyString(true).spanned
+        assertSpannedEquals("$12.00", aud00)
+        assertTtsMarkers("AUD", "12", "00", aud00)
+
+        val aud02 = TransitCurrency.AUD(1202).formatCurrencyString(true).spanned
+        assertSpannedEquals("$12.02", aud02)
+        assertTtsMarkers("AUD", "12", "02", aud02)
+
+        val audMinus = TransitCurrency.AUD(-1202).formatCurrencyString(true).spanned
+        assertSpannedEquals("-$12.02", audMinus)
+        assertTtsMarkers("AUD", "-12", "02", audMinus)
 
         // May be "USD12.34", "U$12.34" or "US$12.34".
         val usd = TransitCurrency.USD(1234).formatCurrencyString(true).spanned
         assertSpannedThat(usd, Matchers.startsWith("U"))
         assertSpannedThat(usd, Matchers.endsWith("12.34"))
-        assertTtsMarkers("USD", "12.34", usd)
+        assertTtsMarkers("USD", "12", "34", usd)
     }
 
     /**
@@ -66,22 +78,22 @@ class TransitCurrencyTest : BaseInstrumentedTest() {
         // May be "$12.34", "U$12.34" or "US$12.34".
         val usd = TransitCurrency.USD(1234).formatCurrencyString(true).spanned
         assertSpannedThat(usd, Matchers.endsWith("$12.34"))
-        assertTtsMarkers("USD", "12.34", usd)
+        assertTtsMarkers("USD", "12", "34", usd)
 
         // May be "A$12.34" or "AU$12.34".
         val aud = TransitCurrency.AUD(1234).formatCurrencyString(true).spanned
         assertSpannedThat(aud, Matchers.startsWith("A"))
         assertSpannedThat(aud, Matchers.endsWith("$12.34"))
-        assertTtsMarkers("AUD", "12.34", aud)
+        assertTtsMarkers("AUD", "12", "34", aud)
 
         val gbp = TransitCurrency(1234, "GBP").formatCurrencyString(true).spanned
         assertSpannedEquals("£12.34", gbp)
-        assertTtsMarkers("GBP", "12.34", gbp)
+        assertTtsMarkers("GBP", "12", "34", gbp)
 
         // May be "¥1,234" or "JP¥1,234".
         val jpy = TransitCurrency.JPY(1234).formatCurrencyString(true).spanned
         assertSpannedThat(jpy, Matchers.endsWith("¥1,234"))
-        assertTtsMarkers("JPY", "1234", jpy)
+        assertTtsMarkers("JPY", "1234", null, jpy)
     }
 
     /**
@@ -94,22 +106,22 @@ class TransitCurrencyTest : BaseInstrumentedTest() {
 
         val usd = TransitCurrency.USD(1234).formatCurrencyString(true).spanned
         assertSpannedEquals("$12.34", usd)
-        assertTtsMarkers("USD", "12.34", usd)
+        assertTtsMarkers("USD", "12", "34", usd)
 
         // May be "A$12.34" or "AU$12.34".
         val aud = TransitCurrency.AUD(1234).formatCurrencyString(true).spanned
         assertSpannedThat(aud, Matchers.startsWith("A"))
         assertSpannedThat(aud, Matchers.endsWith("$12.34"))
-        assertTtsMarkers("AUD", "12.34", aud)
+        assertTtsMarkers("AUD", "12", "34", aud)
 
         val gbp = TransitCurrency(1234, "GBP").formatCurrencyString(true).spanned
         assertSpannedEquals("£12.34", gbp)
-        assertTtsMarkers("GBP", "12.34", gbp)
+        assertTtsMarkers("GBP", "12", "34", gbp)
 
         // May be "¥1,234" or "JP¥1,234".
         val jpy = TransitCurrency.JPY(1234).formatCurrencyString(true).spanned
         assertSpannedThat(jpy, Matchers.endsWith("¥1,234"))
-        assertTtsMarkers("JPY", "1234", jpy)
+        assertTtsMarkers("JPY", "1234", null, jpy)
     }
 
     /**
@@ -125,23 +137,23 @@ class TransitCurrencyTest : BaseInstrumentedTest() {
         // May be "$12.34", "U$12.34" or "US$12.34".
         val usd = TransitCurrency.USD(1234).formatCurrencyString(true).spanned
         assertSpannedThat(usd, Matchers.endsWith("$12.34"))
-        assertTtsMarkers("USD", "12.34", usd)
+        assertTtsMarkers("USD", "12", "34", usd)
 
         // May be "A$12.34" or "AU$12.34".
         val aud = TransitCurrency.AUD(1234).formatCurrencyString(true).spanned
         assertSpannedThat(aud, Matchers.startsWith("A"))
         assertSpannedThat(aud, Matchers.endsWith("$12.34"))
-        assertTtsMarkers("AUD", "12.34", aud)
+        assertTtsMarkers("AUD", "12", "34", aud)
 
         val gbp = TransitCurrency(1234, "GBP").formatCurrencyString(true).spanned
         assertSpannedEquals("£12.34", gbp)
-        assertTtsMarkers("GBP", "12.34", gbp)
+        assertTtsMarkers("GBP", "12", "34", gbp)
 
 
         // Note: this is the full-width yen character
         val jpy = TransitCurrency.JPY(1234).formatCurrencyString(true).spanned
         assertSpannedEquals("￥1,234", jpy)
-        assertTtsMarkers("JPY", "1234", jpy)
+        assertTtsMarkers("JPY", "1234", null, jpy)
     }
 
     /**
@@ -154,16 +166,16 @@ class TransitCurrencyTest : BaseInstrumentedTest() {
 
         val usd = TransitCurrency.USD(1234).formatCurrencyString(true).spanned
         assertSpannedEquals("12,34 \$US", usd)
-        assertTtsMarkers("USD", "12.34", usd)
+        assertTtsMarkers("USD", "12", "34", usd)
 
         val aud = TransitCurrency.AUD(1234).formatCurrencyString(true).spanned
         assertSpannedEquals("12,34 \$AU", aud)
-        assertTtsMarkers("AUD", "12.34", aud)
+        assertTtsMarkers("AUD", "12", "34", aud)
 
         // Allow not qualifying the country code.
         val gbp = TransitCurrency(1234, "GBP").formatCurrencyString(true).spanned
         assertSpannedThat(gbp, Matchers.startsWith("12,34 £"))
-        assertTtsMarkers("GBP", "12.34", gbp)
+        assertTtsMarkers("GBP", "12", "34", gbp)
 
         // This may not have a proper symbol
         val jpy = TransitCurrency.JPY(1234).formatCurrencyString(true).spanned
@@ -172,6 +184,6 @@ class TransitCurrencyTest : BaseInstrumentedTest() {
 
         val eur = TransitCurrency(1234, "EUR").formatCurrencyString(true).spanned
         assertSpannedEquals("12,34 €", eur)
-        assertTtsMarkers("EUR", "12.34", eur)
+        assertTtsMarkers("EUR", "12", "34", eur)
     }
 }

--- a/src/androidUnitTest/kotlin/au/id/micolous/metrodroid/test/BaseInstrumentedTestPlatform.kt
+++ b/src/androidUnitTest/kotlin/au/id/micolous/metrodroid/test/BaseInstrumentedTestPlatform.kt
@@ -43,6 +43,8 @@ actual abstract class BaseInstrumentedTestPlatform {
     val context : Context
         get() = MetrodroidApplication.instance
 
+    val isUnitTest get() = true
+
     actual fun setLocale(languageTag: String) {
         LocaleTools.setLocale(languageTag, context.resources)
     }

--- a/src/main/java/au/id/micolous/metrodroid/transit/TransitCurrency.kt
+++ b/src/main/java/au/id/micolous/metrodroid/transit/TransitCurrency.kt
@@ -4,9 +4,11 @@ import android.text.style.TtsSpan
 import android.os.Build
 import android.text.SpannableString
 import au.id.micolous.metrodroid.multi.FormattedString
+import au.id.micolous.metrodroid.multi.Log
 import au.id.micolous.metrodroid.util.NumberUtils
 import java.text.NumberFormat
 import java.util.*
+import kotlin.math.abs
 
 /**
  * This handles Android-specific issues:
@@ -20,16 +22,13 @@ import java.util.*
  * @return Formatted currency string
  */
 internal actual fun formatCurrency(value: Int, divisor: Int, currencyCode: String, isBalance: Boolean): FormattedString {
-    // numberFormatter is only used for TtsSpan, so needs to give a consistent result.
-    val numberFormatter = NumberFormat.getNumberInstance(Locale.ENGLISH)
-    numberFormatter.isGroupingUsed = false
-
     val c = if (currencyCode != TransitCurrency.UNKNOWN_CURRENCY_CODE)
         Currency.getInstance(currencyCode)
     else
         null
 
     val currencyFormatter: NumberFormat
+    val minimumFractionDigits: Int
     if (c != null) {
         // We have formatting information.
         currencyFormatter = NumberFormat.getCurrencyInstance()
@@ -41,36 +40,43 @@ internal actual fun formatCurrency(value: Int, divisor: Int, currencyCode: Strin
         // In Japanese, AUD is formatted as "A$1" instead of "A$1.23".
         // In English, JPY is formatted as "¥123.00" instead of "¥123"
         currencyFormatter.minimumFractionDigits = c.defaultFractionDigits
-        numberFormatter.minimumFractionDigits = c.defaultFractionDigits
+        minimumFractionDigits = c.defaultFractionDigits
     } else {
         // No formatting information is available.
         currencyFormatter = NumberFormat.getNumberInstance()
 
         // Infer number of decimal places we should add based on the divisor
-        numberFormatter.minimumFractionDigits = NumberUtils.log10floor(divisor)
+        minimumFractionDigits = NumberUtils.log10floor(divisor)
     }
 
     val s: SpannableString
-    val numberOffset: Int
-    val amount: Double
+    val amountPrefix: String
 
     if (!isBalance && value < 0) {
         // Top-ups and refunds get an explicit "positive" marker added, as this list shows
         // debits.
-        amount = Math.abs(value.toDouble() / divisor)
-        s = SpannableString("+ " + currencyFormatter.format(amount))
-        numberOffset = 2
+        s = SpannableString("+ " + currencyFormatter.format(abs(value.toDouble() / divisor)))
+        amountPrefix = "+"
     } else {
-        amount = value.toDouble() / divisor
-        s = SpannableString(currencyFormatter.format(amount))
-        numberOffset = 0
+        s = SpannableString(currencyFormatter.format(value.toDouble() / divisor))
+        amountPrefix = if (value < 0) "-" else ""
     }
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && c != null) {
-        s.setSpan(TtsSpan.MoneyBuilder()
-                .setIntegerPart(numberFormatter.format(amount))
+        val intPart = amountPrefix + (abs(value) / divisor).toString()
+
+        val builder = TtsSpan.MoneyBuilder()
+                .setIntegerPart(intPart)
                 .setCurrency(c.currencyCode)
-                .build(), numberOffset, s.length, 0)
+        if (minimumFractionDigits != 0) {
+            val fraction = NumberUtils.zeroPad((NumberUtils.pow(10, minimumFractionDigits)
+                    * (abs(value) % divisor)) / divisor,
+                    minDigits = minimumFractionDigits)
+            builder.setFractionalPart(fraction)
+            Log.d("TransitCurrency", "Money ($value/$divisor) = $intPart / $fraction")
+        } else
+            Log.d("TransitCurrency", "Money ($value/$divisor) = $intPart")
+        s.setSpan(builder.build(), 0, s.length, 0)
     }
 
     return FormattedString(s)


### PR DESCRIPTION
Robolectric formatting is worse than android but is overall acceptable. Accept it only when running as unit test