### PR TITLE
Support reading Mifare Plus

### DIFF
--- a/native/metrodroid/metrodroid/NFCReader.swift
+++ b/native/metrodroid/metrodroid/NFCReader.swift
@@ -257,7 +257,7 @@ class NFCReader : NSObject, NFCTagReaderSessionDelegate, TagReaderFeedbackInterf
                     }
                 })
                 break
-            case NFCMiFareFamily.plus:
+            case .plus:
                 statusConnecting(cardType: .mifareplus)
                 session.connect(to: tag, completionHandler: {
                     err in

--- a/native/metrodroid/metrodroid/SupportedCardsViewController.swift
+++ b/native/metrodroid/metrodroid/SupportedCardsViewController.swift
@@ -25,9 +25,11 @@ import metrolib
 class SupportedCardsViewController: UICollectionViewController {
     
     let reuseIdentifier = "cell" // also enter this string as the cell identifier in the storyboard
+    // Classic is not supported currently
+    static let supportedProtocols: [CardType] = [
+        .felica, .iso7816, .mifaredesfire, .mifareultralight, .mifareplus, .vicinity]
     class func isSupported(cardInfo: CardInfo) -> Bool {
-        // Classic and vicinity are not supported currently
-        return cardInfo.iOSSupported as? Bool ?? (cardInfo.cardType == CardType.iso7816 || cardInfo.cardType == CardType.mifaredesfire || cardInfo.cardType == CardType.felica || cardInfo.cardType == CardType.mifareultralight || cardInfo.cardType == CardType.vicinity)
+        return cardInfo.iOSSupported as? Bool ?? supportedProtocols.contains(cardInfo.cardType)
     }
     var items = CardInfoRegistry.init().allCardsAlphabetical.filter {
         isSupported(cardInfo: $0) }

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/Card.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/Card.kt
@@ -112,7 +112,10 @@ class Card(
     val cardType: CardType
         get () = when {
             allProtocols.size > 1 -> CardType.MultiProtocol
-            mifareClassic != null -> CardType.MifareClassic
+            mifareClassic != null -> when (mifareClassic.subType) {
+                ClassicCard.SubType.CLASSIC -> CardType.MifareClassic
+                ClassicCard.SubType.PLUS -> CardType.MifarePlus
+            }
             mifareUltralight != null -> CardType.MifareUltralight
             mifareDesfire != null -> CardType.MifareDesfire
             cepasCompat != null -> CardType.CEPAS

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/CardType.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/CardType.kt
@@ -28,6 +28,7 @@ enum class CardType constructor(private val mValue: Int) {
     ISO7816(5),
     MultiProtocol(7),
     Vicinity(8),
+    MifarePlus(9),
     Unknown(65535);
 
     fun toInteger() = mValue
@@ -42,6 +43,7 @@ enum class CardType constructor(private val mValue: Int) {
         6 -> "Calypso"
         7 -> "Multi-protocol"
         8 -> "Vicinity"
+        9 -> "MIFARE Plus"
         65535 -> "Unknown"
         else -> "Unknown"
     }

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/classic/ClassicAuthenticator.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/classic/ClassicAuthenticator.kt
@@ -40,7 +40,7 @@ class ClassicAuthenticator internal constructor(private val mKeys: ClassicKeys,
                                                 private val mRetryLimit: Int = Preferences.mfcAuthRetry,
                                                 private val mPreferredBundles: MutableList<String> = mutableListOf()
                                                ) {
-    private fun tryKey(tech: ClassicCardTech,
+    private suspend fun tryKey(tech: ClassicCardTech,
                        sectorIndex: Int,
                        sectorKey: ClassicSectorKey): Boolean {
         if (!tech.authenticate(sectorIndex, sectorKey))
@@ -51,7 +51,7 @@ class ClassicAuthenticator internal constructor(private val mKeys: ClassicKeys,
         return true
     }
 
-    private fun tryCandidatesSub(tech: ClassicCardTech,
+    private suspend fun tryCandidatesSub(tech: ClassicCardTech,
                                  sectorIndex: Int,
                                  candidates: Collection<ClassicSectorKey>): ClassicSectorKey? {
         candidates.forEach { sectorKey ->
@@ -61,7 +61,7 @@ class ClassicAuthenticator internal constructor(private val mKeys: ClassicKeys,
         return null
     }
 
-    private fun tryCandidates(tech: ClassicCardTech,
+    private suspend fun tryCandidates(tech: ClassicCardTech,
                               sectorIndex: Int,
                               candidates: Collection<ClassicSectorKey>,
                               keyType: ClassicSectorKey.KeyType): ClassicSectorKey? {
@@ -74,7 +74,7 @@ class ClassicAuthenticator internal constructor(private val mKeys: ClassicKeys,
         return null
     }
 
-    fun authenticate(tech: ClassicCardTech,
+    suspend fun authenticate(tech: ClassicCardTech,
                      feedbackInterface: TagReaderFeedbackInterface,
                      sectorIndex: Int,
                      expectDynamic: Boolean,

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/classic/ClassicCard.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/classic/ClassicCard.kt
@@ -38,7 +38,13 @@ class ClassicCard constructor(
         @XMLListIdx("index")
         @SerialName("sectors")
         val sectorsRaw: List<ClassicSectorRaw>,
+        val subType: SubType = SubType.CLASSIC,
         override val isPartialRead: Boolean = false) : CardProtocol() {
+
+    enum class SubType {
+        CLASSIC,
+        PLUS;
+    }
 
     companion object {
         @VisibleForTesting
@@ -94,7 +100,11 @@ class ClassicCard constructor(
             : this(sectorsRaw = sectors.map { it.raw }, isPartialRead = false)
 
     private fun findTransitFactory(): ClassicCardTransitFactory? {
-        for (factory in ClassicCardFactoryRegistry.allFactories) {
+        val factories = when (subType) {
+            SubType.CLASSIC -> ClassicCardFactoryRegistry.classicFactories
+            SubType.PLUS -> ClassicCardFactoryRegistry.plusFactories
+        }
+        for (factory in factories) {
             try {
                 if (factory.check(this))
                     return factory

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/classic/ClassicCardFactoryRegistry.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/classic/ClassicCardFactoryRegistry.kt
@@ -37,7 +37,7 @@ import au.id.micolous.metrodroid.transit.warsaw.WarsawTransitData
 import au.id.micolous.metrodroid.transit.zolotayakorona.ZolotayaKoronaTransitData
 
 object ClassicCardFactoryRegistry {
-    val allFactories = listOf(
+    val classicFactories = listOf(
             OVChipTransitData.FACTORY,
 
             // ERG
@@ -93,4 +93,16 @@ object ClassicCardFactoryRegistry {
             //
             // This is for agencies who don't have identifying "magic" in their card.
             FallbackFactory)
+
+    val plusFactories = listOf(
+            // This check must be THIRD TO LAST.
+            //
+            // This is to throw up a warning whenever there is a card with all locked sectors
+            UnauthorizedClassicTransitData.FACTORY,
+            // This check must be SECOND TO LAST.
+            //
+            // This is to throw up a warning whenever there is a card with all empty sectors
+            BlankClassicTransitData.FACTORY
+    )
+    val allFactories = classicFactories + plusFactories
 }

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/classic/ClassicCardTech.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/classic/ClassicCardTech.kt
@@ -26,10 +26,12 @@ import au.id.micolous.metrodroid.key.ClassicSectorKey
 import au.id.micolous.metrodroid.util.ImmutableByteArray
 
 interface ClassicCardTech {
-    fun authenticate(sectorIndex: Int, key: ClassicSectorKey): Boolean
+    suspend fun authenticate(sectorIndex: Int, key: ClassicSectorKey): Boolean
     val sectorCount: Int
     val tagId: ImmutableByteArray
-    fun readBlock(block: Int): ImmutableByteArray
+    suspend fun readBlock(block: Int): ImmutableByteArray
     fun getBlockCountInSector(sectorIndex: Int): Int
     fun sectorToBlock(sectorIndex: Int): Int
+    val subType: ClassicCard.SubType
+        get() = ClassicCard.SubType.CLASSIC
 }

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/classic/ClassicReader.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/classic/ClassicReader.kt
@@ -156,6 +156,12 @@ object ClassicReader {
         return ClassicCard(sectorsRaw = sectors.map { it.raw }, isPartialRead = false, subType = tech.subType)
     }
 
+    suspend fun readPlusCardNoSak(retriever: CardKeysRetriever, tag: CardTransceiver,
+                                  feedbackInterface: TagReaderFeedbackInterface): ClassicCard? {
+        val protocol = PlusProtocol.connect(tag) ?: return null
+        return readCard(retriever, protocol, feedbackInterface)
+    }
+
     suspend fun readPlusCard(retriever: CardKeysRetriever, tag: CardTransceiver,
                              feedbackInterface: TagReaderFeedbackInterface,
                              atqa: Int, sak: Short): ClassicCard? {
@@ -164,7 +170,6 @@ object ClassicReader {
         if (sak != 0x20.toShort() || atqa !in listOf(0x0002, 0x0004, 0x0042, 0x0044))
             return null
 
-        val protocol = PlusProtocol.connect(tag) ?: return null
-        return readCard(retriever, protocol, feedbackInterface)
+        return readPlusCardNoSak(retriever, tag, feedbackInterface)
     }
 }

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/classic/MifarePlusWrapper.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/classic/MifarePlusWrapper.kt
@@ -1,0 +1,133 @@
+/*
+ * MifarePlusWrapper.kt
+ *
+ * Copyright 2018 Merlok
+ * Copyright 2018 drHatson
+ * Copyright 2019 Google
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package au.id.micolous.metrodroid.card.classic
+
+import au.id.micolous.metrodroid.key.ClassicSectorKey
+import au.id.micolous.metrodroid.multi.Log
+import au.id.micolous.metrodroid.util.Aes
+import au.id.micolous.metrodroid.util.Cmac
+import au.id.micolous.metrodroid.util.ImmutableByteArray
+import au.id.micolous.metrodroid.card.CardTransceiver
+
+class MifarePlusWrapper private constructor(private val tag: CardTransceiver,
+                                            override val sectorCount: Int) : ClassicCardTech {
+    var kmac: ImmutableByteArray? = null
+    var ti: ImmutableByteArray? = null
+    var rctr: Int = 0
+    
+    override fun getBlockCountInSector(sectorIndex: Int) = if (sectorIndex >= 32) 16 else 4
+
+    override fun sectorToBlock(sectorIndex: Int) = if (sectorIndex < 32) sectorIndex * 4 else
+        (16 * sectorIndex - 32 * 12)
+
+    override val tagId: ImmutableByteArray
+        get() = tag.uid!!
+
+    private fun aesCmac8(macdata: ImmutableByteArray, key: ImmutableByteArray): ImmutableByteArray {
+        val cmac = Cmac.aesCmac(macdata, key)
+        return ImmutableByteArray(8) { cmac[2 * it + 1] }
+    }
+
+    private fun rotate(input: ImmutableByteArray) = input.sliceOffLen(1, input.size - 1) + input.sliceOffLen(0,1)
+
+    override suspend fun authenticate(sectorIndex: Int, key: ClassicSectorKey): Boolean {
+        if (key.key.size != 16) {
+            return false
+        }
+        val keyNum = 2 * sectorIndex + (if (key.type == ClassicSectorKey.KeyType.B) 1 else 0) + 0x4000
+        val cmd = ImmutableByteArray.of(0x70, keyNum.toByte(), (keyNum shr 8).toByte(), 0x06,
+                0, 0, 0, 0, 0, 0)
+        val reply = tag.transceive(cmd)
+        if (reply.size != 17 || reply[0] != 0x90.toByte()) {
+            Log.w(TAG, "Card response error $reply")
+            return false
+        }
+
+        val rndA = ImmutableByteArray(16) { (it * it).toByte() } // Doesn't matter
+        val rndB = Aes.decryptCbc(reply.sliceOffLen(1, 16), key.key)
+
+        val raw = rndA + rotate(rndB)
+
+        val cmd2 = ImmutableByteArray.of(0x72) + Aes.encryptCbc(raw, key.key)
+        val reply2 = tag.transceive(cmd2)
+
+        if (reply2.size < 33) {
+            Log.w(TAG, "Card response error $reply2")
+            return false
+        }
+
+        val raw2 = Aes.decryptCbc(reply2.sliceOffLen(1, 32), key.key)
+        val rndAPrime = raw2.sliceOffLen(4, 16)
+
+        if (rndAPrime != rotate(rndA)) {
+            return false
+        }
+
+        val kmacPlain = rndA.sliceOffLen(7, 5) + rndB.sliceOffLen(7, 5) +
+                (rndA.sliceOffLen(0, 5) xor rndB.sliceOffLen(0, 5)) + ImmutableByteArray.of(0x22)
+        ti = raw2.sliceOffLen(0, 4)
+        kmac = Aes.encryptCbc(kmacPlain, key.key)
+        rctr = 0
+        return true
+    }
+
+    private fun computeMac(input: ImmutableByteArray, ctr: Int): ImmutableByteArray {
+        val macdata = ImmutableByteArray.of(input[0], ctr.toByte(), (ctr shr 8).toByte()) +
+                ti!! + input.sliceOffLen(1, input.size - 1)
+        return aesCmac8(key=kmac!!, macdata=macdata)
+    }
+
+    override suspend fun readBlock(block: Int): ImmutableByteArray {
+        val cmd = ImmutableByteArray.of(0x33, block.toByte(), 0, 1)
+        val reply = tag.transceive(cmd + computeMac(cmd, rctr))
+        rctr++
+
+        return reply.sliceOffLen(1, 16)
+    }
+
+    override val subType: ClassicCard.SubType
+        get() = ClassicCard.SubType.PLUS
+
+    companion object {
+        private const val TAG = "MifarePlusWrapper"
+
+        private suspend fun checkSectorPresence(tag: CardTransceiver, sectorIndex: Int): Boolean {
+            val keyNum = 2 * sectorIndex + 0x4000
+            val cmd = ImmutableByteArray.of(0x70, keyNum.toByte(), (keyNum shr 8).toByte(), 0x06,
+                                            0, 0, 0, 0, 0, 0)
+            val reply = tag.transceive(cmd)
+            return (reply.size == 17 && reply[0] == 0x90.toByte())
+        }
+
+        suspend fun wrap(tag: CardTransceiver): MifarePlusWrapper? {
+            try {
+                if (!checkSectorPresence(tag, 0)) {
+                    return null
+                }
+                val capacity = if (checkSectorPresence(tag, 32)) 40 else 32
+                return MifarePlusWrapper(tag = tag, sectorCount = capacity)
+            } catch (e: Exception) {
+                return null
+            }
+        }
+    }
+}

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/key/CardKeysFromFiles.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/key/CardKeysFromFiles.kt
@@ -126,3 +126,11 @@ class CardKeysFromFiles(private val fileReader: CardKeysFileReader) : CardKeysRe
         private const val TAG = "CardKeysFromFiles"
     }
 }
+
+class CardKeysDummy : CardKeysRetriever {
+    override fun forClassicStatic(): ClassicStaticKeys? = null
+
+    override fun forID(id: Int) = null
+
+    override fun forTagID(tagID: ImmutableByteArray): CardKeys? = null
+}

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/key/ClassicCardKeys.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/key/ClassicCardKeys.kt
@@ -92,9 +92,8 @@ class ClassicCardKeys(override var uid: String?,
             val numSectors = keyData.size / ClassicSectorKey.CLASSIC_KEY_LEN
             for (i in 0 until numSectors) {
                 val start = i * ClassicSectorKey.CLASSIC_KEY_LEN
-                val k = ClassicSectorKey.fromDump(keyData, start, keyType,
-                        "from-dump")
-                keys[i] = listOf(k)
+                val key = keyData.sliceOffLen(start, ClassicSectorKey.CLASSIC_KEY_LEN)
+                keys[i] = listOf(ClassicSectorKey.fromDump(key, keyType, "from-dump"))
             }
 
             return ClassicCardKeys(uid = null, keys = keys, sourceDataLength = keyData.size)

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/key/ClassicCardKeys.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/key/ClassicCardKeys.kt
@@ -89,9 +89,9 @@ class ClassicCardKeys(override var uid: String?,
         fun fromDump(keyData: ImmutableByteArray, keyType: ClassicSectorKey.KeyType): ClassicCardKeys {
             val keys = mutableMapOf<Int, List<ClassicSectorKey>>()
 
-            val numSectors = keyData.size / ClassicSectorKey.KEY_LEN
+            val numSectors = keyData.size / ClassicSectorKey.CLASSIC_KEY_LEN
             for (i in 0 until numSectors) {
-                val start = i * ClassicSectorKey.KEY_LEN
+                val start = i * ClassicSectorKey.CLASSIC_KEY_LEN
                 val k = ClassicSectorKey.fromDump(keyData, start, keyType,
                         "from-dump")
                 keys[i] = listOf(k)

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/key/ClassicKeysImpl.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/key/ClassicKeysImpl.kt
@@ -112,7 +112,11 @@ abstract class ClassicKeysImpl : ClassicKeys {
                 wellKnown("ffffffffffff", "well-known-ff"),
                 wellKnown("000000000000", "well-known-zero"),
                 wellKnown("a0a1a2a3a4a5", "well-known-mad"),
-                wellKnown("d3f7d3f7d3f7", "well-known-ndef"))
+                wellKnown("d3f7d3f7d3f7", "well-known-ndef"),
+                wellKnown("ffffffffffffffffffffffffffffffff", "well-known-ff-aes"),
+                wellKnown("00000000000000000000000000000000", "well-known-zero-aes"),
+                wellKnown("a0a1a2a3a4a5a6a7a0a1a2a3a4a5a6a7", "well-known-mad-aes"),
+                wellKnown("d3f7d3f7d3f7d3f7d3f7d3f7d3f7d3f7", "well-known-ndef-aes"))
 
         fun keysFromJSON(jsonRoot: JsonObject, allowMissingIdx: Boolean, defaultBundle: String):
                 Map<Int, List<ClassicSectorAlgoKey>> {

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/key/ClassicSectorKey.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/key/ClassicSectorKey.kt
@@ -139,17 +139,17 @@ data class ClassicSectorKey internal constructor(
         }
 
     companion object {
-        internal const val KEY_LEN = 6
+        internal const val CLASSIC_KEY_LEN = 6
+        internal const val AES_KEY_LEN = 16
         const val KEY_TYPE = "type"
         const val KEY_VALUE = "key"
         const val SECTOR_IDX = "sector"
         const val TYPE_KEYA = "KeyA"
         const val TYPE_KEYB = "KeyB"
 
-
         fun fromDump(b: ImmutableByteArray, type: KeyType, bundle: String): ClassicSectorKey {
-            if (b.size != KEY_LEN) {
-                throw IllegalArgumentException("Key data must be $KEY_LEN bytes, got ${b.size}")
+            if (b.size != CLASSIC_KEY_LEN && b.size != AES_KEY_LEN) {
+                throw IllegalArgumentException("Key data must be $CLASSIC_KEY_LEN or $AES_KEY_LEN bytes, got ${b.size}")
             }
 
             return ClassicSectorKey(key = b,
@@ -157,7 +157,7 @@ data class ClassicSectorKey internal constructor(
         }
 
         fun fromDump(b: ImmutableByteArray, offset: Int, type: KeyType, bundle: String) =
-                fromDump(b.sliceOffLen(offset, ClassicSectorKey.KEY_LEN),
+                fromDump(b.sliceOffLen(offset, ClassicSectorKey.CLASSIC_KEY_LEN),
                         type, bundle)
     }
 }

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/key/ClassicSectorKey.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/key/ClassicSectorKey.kt
@@ -152,12 +152,7 @@ data class ClassicSectorKey internal constructor(
                 throw IllegalArgumentException("Key data must be $CLASSIC_KEY_LEN or $AES_KEY_LEN bytes, got ${b.size}")
             }
 
-            return ClassicSectorKey(key = b,
-                    type = type, bundle = bundle)
+            return ClassicSectorKey(key = b, type = type, bundle = bundle)
         }
-
-        fun fromDump(b: ImmutableByteArray, offset: Int, type: KeyType, bundle: String) =
-                fromDump(b.sliceOffLen(offset, ClassicSectorKey.CLASSIC_KEY_LEN),
-                        type, bundle)
     }
 }

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/umarsh/UmarshTransitData.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/umarsh/UmarshTransitData.kt
@@ -32,6 +32,8 @@ import au.id.micolous.metrodroid.util.HashUtils
 import au.id.micolous.metrodroid.util.ImmutableByteArray
 import au.id.micolous.metrodroid.util.NumberUtils
 
+import kotlin.native.concurrent.SharedImmutable
+
 internal enum class UmarshDenomination {
     UNLIMITED,
     TRIPS,
@@ -51,7 +53,7 @@ internal data class UmarshSystem(
 
 // This implements reader for umarsh format: https://umarsh.com
 // Reference: https://github.com/micolous/metrodroid/wiki/Umarsh
-
+@SharedImmutable
 private val systemsMap = mapOf(
         12 to UmarshSystem(
                 CardInfo(

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/unknown/UnauthorizedClassicTransitData.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/unknown/UnauthorizedClassicTransitData.kt
@@ -29,15 +29,14 @@ import au.id.micolous.metrodroid.transit.TransitIdentity
 /**
  * Handle MIFARE Classic with no open sectors
  */
-@Suppress("PLUGIN_WARNING")
 @Parcelize
-class UnauthorizedClassicTransitData private constructor() : UnauthorizedTransitData() {
+class UnauthorizedClassicTransitData private constructor(val subtype: ClassicCard.SubType) : UnauthorizedTransitData() {
 
     override val cardName: String
         get() = Localizer.localizeString(R.string.locked_mfc_card)
 
     override val isUnlockable: Boolean
-        get() = true
+        get() = subtype == ClassicCard.SubType.CLASSIC
 
     companion object {
         val FACTORY: ClassicCardTransitFactory = object : ClassicCardTransitFactory {
@@ -57,7 +56,7 @@ class UnauthorizedClassicTransitData private constructor() : UnauthorizedTransit
                     TransitIdentity(Localizer.localizeString(R.string.locked_mfc_card), null)
 
             override fun parseTransitData(card: ClassicCard) =
-                    UnauthorizedClassicTransitData()
+                    UnauthorizedClassicTransitData(subtype = card.subType)
         }
     }
 }

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/util/Aes.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/util/Aes.kt
@@ -1,0 +1,9 @@
+package au.id.micolous.metrodroid.util
+
+expect object Aes {
+    fun decryptCbc(encrypted: ImmutableByteArray, key: ImmutableByteArray,
+                   iv: ImmutableByteArray=ImmutableByteArray.empty(16)): ImmutableByteArray
+
+    fun encryptCbc(decrypted: ImmutableByteArray, key: ImmutableByteArray,
+                   iv: ImmutableByteArray=ImmutableByteArray.empty(16)): ImmutableByteArray
+}

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/util/Cmac.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/util/Cmac.kt
@@ -1,0 +1,62 @@
+/*
+ * Cmac.kt
+ *
+ * Copyright 2019 Google
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package au.id.micolous.metrodroid.util
+
+object Cmac {
+    private fun cmacPad(input: ImmutableByteArray) = input + ImmutableByteArray.of(0x80.toByte()) +
+            ImmutableByteArray(16 - input.size - 1) { 0.toByte() }
+
+    private fun shl1(input: ImmutableByteArray) = ImmutableByteArray(input.size) {
+        ((input[it].toInt() shl 1) or ((if (it == input.size - 1) 0 else input[it + 1].toInt() and 0x80) shr 7)).toByte()
+    }
+
+    private fun cmacSubkeys(cipher: (ImmutableByteArray) -> ImmutableByteArray): Pair<ImmutableByteArray, ImmutableByteArray> {
+        val l = cipher(ImmutableByteArray.empty(16))
+
+        val rb = ImmutableByteArray.fromHex("00000000000000000000000000000087")
+        val k1 = if (l[0].toInt() and 0x80 == 0) {
+            shl1(l)
+        } else {
+            shl1(l) xor rb
+        }
+        val k2 = if (k1[0].toInt() and 0x80 == 0) {
+            shl1(k1)
+        } else {
+            shl1(k1) xor rb
+        }
+        return Pair(k1, k2)
+    }
+
+    private fun cmac(macdata: ImmutableByteArray, cipher: (ImmutableByteArray) -> ImmutableByteArray): ImmutableByteArray {
+        var x = ImmutableByteArray.empty(16)
+        val (k1, k2) = cmacSubkeys(cipher)
+        val n = (macdata.size + 15) / 16
+        for (i in 0..(n - 2)) {
+            x = cipher(x xor macdata.sliceOffLen(16 * i, 16))
+        }
+        val lastBlockStart = (n - 1) * 16
+        val lastBlock = macdata.sliceOffLen(lastBlockStart, macdata.size - lastBlockStart)
+        val mlast = if (lastBlock.size == 16) lastBlock xor k1 else cmacPad(lastBlock) xor k2
+        return cipher(mlast xor x)
+    }
+
+    fun aesCmac(macdata: ImmutableByteArray, key: ImmutableByteArray): ImmutableByteArray = cmac(
+            macdata) { Aes.encryptCbc(it, key)}
+}

--- a/src/commonTest/kotlin/au/id/micolous/metrodroid/test/ClassicReaderTest.kt
+++ b/src/commonTest/kotlin/au/id/micolous/metrodroid/test/ClassicReaderTest.kt
@@ -51,7 +51,7 @@ class ClassicReaderTest : BaseInstrumentedTest() {
         TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
     }*/
 
-    fun doTest(path: String) {
+    fun doTest(path: String) = runAsync {
         val auth = CardKeysFromFiles(keyReader(path))
         for (dump in listAsset("$path/dumps").orEmpty()) {
             val raw = loadSmallAssetBytes("$path/dumps/$dump").toImmutable()

--- a/src/commonTest/kotlin/au/id/micolous/metrodroid/test/VirtualClassic.kt
+++ b/src/commonTest/kotlin/au/id/micolous/metrodroid/test/VirtualClassic.kt
@@ -45,7 +45,7 @@ class VirtualClassic(private val raw: ImmutableByteArray) : ClassicCardTech {
             return keyZero + block.sliceOffLen(6, 10)
     }
 
-    override fun authenticate(sectorIndex: Int, key: ClassicSectorKey): Boolean {
+    override suspend fun authenticate(sectorIndex: Int, key: ClassicSectorKey): Boolean {
         authCounter++
         val type = key.type
         val accBits = getAccessBits(sectorIndex)
@@ -71,7 +71,7 @@ class VirtualClassic(private val raw: ImmutableByteArray) : ClassicCardTech {
             else -> throw IllegalArgumentException()
         }
 
-    override fun readBlock(block: Int): ImmutableByteArray {
+    override suspend fun readBlock(block: Int): ImmutableByteArray {
         readCounter++
         val sectorIdx = blockToSector(block)
         // TODO: verify behaviour in this case on real card

--- a/src/iOSMain/kotlin/au/id/micolous/metrodroid/card/classic/PlusCardReaderIOS.kt
+++ b/src/iOSMain/kotlin/au/id/micolous/metrodroid/card/classic/PlusCardReaderIOS.kt
@@ -1,0 +1,56 @@
+/*
+ * DesfireCardReaderIOS.kt
+ *
+ * Copyright 2019 Google
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package au.id.micolous.metrodroid.card.classic
+
+import au.id.micolous.metrodroid.card.Card
+import au.id.micolous.metrodroid.card.ultralight.UltralightTransceiverIOS
+import au.id.micolous.metrodroid.card.TagReaderFeedbackInterface
+import au.id.micolous.metrodroid.key.CardKeysDummy
+import au.id.micolous.metrodroid.multi.Log
+import au.id.micolous.metrodroid.multi.Localizer
+import au.id.micolous.metrodroid.multi.NativeThrows
+import au.id.micolous.metrodroid.multi.R
+import au.id.micolous.metrodroid.time.TimestampFull
+import kotlinx.coroutines.runBlocking
+
+object PlusCardReaderIOS {
+    @NativeThrows
+    fun dump(wrapper: UltralightTransceiverIOS.SwiftWrapper,
+             feedback: TagReaderFeedbackInterface): Card {
+        val xfer = UltralightTransceiverIOS(wrapper)
+        Log.d(TAG, "Start dump ${xfer.uid}")
+        return runBlocking {
+            Log.d(TAG, "Start async")
+            feedback.updateStatusText(Localizer.localizeString(R.string.mfp_reading))
+            feedback.showCardType(null)
+
+            val techWrapper = MifarePlusWrapper.wrap(xfer) ?: throw Exception("Unknown MifarePlus")
+
+            val keyRetriever = CardKeysDummy()
+
+            val p = ClassicReader.readCard(
+                keyRetriever, techWrapper, feedback)
+            Card(tagId = xfer.uid?.let { if (it.size == 10) it.sliceOffLen(0, 7) else it }!!,
+                scannedAt = TimestampFull.now(), mifareClassic = p)
+        }
+    }
+
+    private const val TAG = "PlusCardReaderIOS"
+}

--- a/src/iOSMain/kotlin/au/id/micolous/metrodroid/util/Aes.kt
+++ b/src/iOSMain/kotlin/au/id/micolous/metrodroid/util/Aes.kt
@@ -1,0 +1,46 @@
+package au.id.micolous.metrodroid.util
+
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import platform.CoreCrypto.*
+
+actual object Aes {
+    private fun aesOp(mode: CCOperation, input: ImmutableByteArray, key: ImmutableByteArray, iv: ImmutableByteArray) : ImmutableByteArray {
+        if (key.size != 16 || iv.size != 16 || input.size % 16 != 0)
+            throw IllegalArgumentException("Invalid crypro argument size")
+        val output = ByteArray(input.size) { 0.toByte() }
+        val outputSize = ULongArray(1) { 0u }
+        key.dataCopy.usePinned { keyPinned ->
+            iv.dataCopy.usePinned { ivPinned ->
+                input.dataCopy.usePinned { inputPinned ->
+                    output.usePinned { outputPinned ->
+                        outputSize.usePinned { outputSizePinned ->
+                            val ccStatus = CCCrypt(mode,
+                                    kCCAlgorithmAES128,
+                                    0,
+                                    keyPinned.addressOf(0),
+                                    key.size.toULong(),
+                                    ivPinned.addressOf(0),
+                                    inputPinned.addressOf(0),
+                                    input.size.toULong(),
+                                    outputPinned.addressOf(0),
+                                    output.size.toULong(),
+                                    outputSizePinned.addressOf(0))
+                        }
+                    }
+                }
+            }
+        }
+        return output.toImmutable()
+    }
+
+    actual fun decryptCbc(encrypted: ImmutableByteArray, key: ImmutableByteArray,
+                          iv: ImmutableByteArray): ImmutableByteArray = aesOp(
+            kCCDecrypt, encrypted, key, iv
+    )
+
+    actual fun encryptCbc(decrypted: ImmutableByteArray, key: ImmutableByteArray,
+                          iv: ImmutableByteArray): ImmutableByteArray = aesOp(
+            kCCEncrypt, decrypted, key, iv
+    )
+}

--- a/src/jvmCommonMain/kotlin/au/id/micolous/metrodroid/util/Aes.kt
+++ b/src/jvmCommonMain/kotlin/au/id/micolous/metrodroid/util/Aes.kt
@@ -1,0 +1,44 @@
+/*
+ * Aes.kt
+ *
+ * Copyright 2019 Google
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package au.id.micolous.metrodroid.util
+
+import javax.crypto.Cipher
+import javax.crypto.SecretKey
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+actual object Aes {
+    private fun aesOp(mode: Int, input: ImmutableByteArray, key: ImmutableByteArray, iv: ImmutableByteArray) : ImmutableByteArray {
+        val cipherkey: SecretKey = SecretKeySpec(key.dataCopy, "AES")
+        val cipher = Cipher.getInstance("AES/CBC/NoPadding")
+        cipher.init(mode, cipherkey, IvParameterSpec(iv.dataCopy))
+        return cipher.doFinal(input.dataCopy).toImmutable()
+    }
+
+    actual fun decryptCbc(encrypted: ImmutableByteArray, key: ImmutableByteArray,
+                          iv: ImmutableByteArray): ImmutableByteArray = aesOp(
+            Cipher.DECRYPT_MODE, encrypted, key, iv
+    )
+
+    actual fun encryptCbc(decrypted: ImmutableByteArray, key: ImmutableByteArray,
+                          iv: ImmutableByteArray): ImmutableByteArray = aesOp(
+            Cipher.ENCRYPT_MODE, decrypted, key, iv
+    )
+}

--- a/src/main/java/au/id/micolous/metrodroid/card/AndroidCardTransceiver.kt
+++ b/src/main/java/au/id/micolous/metrodroid/card/AndroidCardTransceiver.kt
@@ -155,10 +155,6 @@ class AndroidNfcATransceiver(private val tag: Tag) : CardTransceiver, Closeable 
         private set
 
     private var nfcA: NfcA? = null
-    var sak: Short? = null
-        private set
-    var atqa: ImmutableByteArray? = null
-        private set
 
     fun connect() {
         close()
@@ -166,8 +162,6 @@ class AndroidNfcATransceiver(private val tag: Tag) : CardTransceiver, Closeable 
         val nfcA = NfcA.get(tag) ?: throw CardProtocolUnsupportedException("ISO14443-A")
 
         nfcA.connect()
-        this.sak = nfcA.sak
-        this.atqa = nfcA.atqa.toImmutable()
         this.nfcA = nfcA
 
         uid = tag.id.toImmutable()

--- a/src/main/java/au/id/micolous/metrodroid/card/classic/ClassicAndroidReader.kt
+++ b/src/main/java/au/id/micolous/metrodroid/card/classic/ClassicAndroidReader.kt
@@ -33,6 +33,7 @@ import au.id.micolous.metrodroid.multi.Localizer
 import au.id.micolous.farebot.R
 import au.id.micolous.metrodroid.MetrodroidApplication
 import au.id.micolous.metrodroid.card.TagReaderFeedbackInterface
+import au.id.micolous.metrodroid.card.CardTransceiver
 import au.id.micolous.metrodroid.util.ImmutableByteArray
 
 import au.id.micolous.metrodroid.key.CardKeysEmbed
@@ -90,7 +91,7 @@ object ClassicAndroidReader {
                 CardKeysDB(context)
         ))
 
-    fun dumpTag(tagId: ImmutableByteArray, tag: Tag, feedbackInterface: TagReaderFeedbackInterface): ClassicCard {
+    suspend fun dumpTag(tagId: ImmutableByteArray, tag: Tag, feedbackInterface: TagReaderFeedbackInterface): ClassicCard {
         feedbackInterface.updateStatusText(Localizer.localizeString(R.string.mfc_reading))
         feedbackInterface.showCardType(null)
 
@@ -111,5 +112,20 @@ object ClassicAndroidReader {
                 tech.close()
             }
         }
+    }
+
+
+    suspend fun dumpPlus(tag: CardTransceiver, feedbackInterface: TagReaderFeedbackInterface,
+                         atqa: Int, sak: Short): ClassicCard? {
+        if (sak != 0x20.toShort() || atqa !in listOf(0x0002, 0x0004, 0x0042, 0x0044))
+            return null
+        val techWrapper = MifarePlusWrapper.wrap(tag) ?: return null
+        feedbackInterface.updateStatusText(Localizer.localizeString(R.string.mfp_reading))
+        feedbackInterface.showCardType(null)
+
+        val keyRetriever = getKeyRetriever(MetrodroidApplication.instance)
+
+        return ClassicReader.readCard(
+            keyRetriever, techWrapper, feedbackInterface)
     }
 }

--- a/src/main/java/au/id/micolous/metrodroid/card/classic/ClassicAndroidReader.kt
+++ b/src/main/java/au/id/micolous/metrodroid/card/classic/ClassicAndroidReader.kt
@@ -114,18 +114,12 @@ object ClassicAndroidReader {
         }
     }
 
-
     suspend fun dumpPlus(tag: CardTransceiver, feedbackInterface: TagReaderFeedbackInterface,
                          atqa: Int, sak: Short): ClassicCard? {
-        if (sak != 0x20.toShort() || atqa !in listOf(0x0002, 0x0004, 0x0042, 0x0044))
-            return null
-        val techWrapper = MifarePlusWrapper.wrap(tag) ?: return null
         feedbackInterface.updateStatusText(Localizer.localizeString(R.string.mfp_reading))
         feedbackInterface.showCardType(null)
 
         val keyRetriever = getKeyRetriever(MetrodroidApplication.instance)
-
-        return ClassicReader.readCard(
-            keyRetriever, techWrapper, feedbackInterface)
+        return ClassicReader.readPlusCard(keyRetriever, tag, feedbackInterface, atqa, sak)
     }
 }

--- a/src/main/java/au/id/micolous/metrodroid/card/classic/ClassicCardTechAndroid.kt
+++ b/src/main/java/au/id/micolous/metrodroid/card/classic/ClassicCardTechAndroid.kt
@@ -36,8 +36,10 @@ class ClassicCardTechAndroid(private val tech: MifareClassic,
 
     override fun getBlockCountInSector(sectorIndex: Int) = tech.getBlockCountInSector(sectorIndex)
 
-    override fun authenticate(sectorIndex: Int, key: ClassicSectorKey): Boolean = wrapAndroidExceptions {
-        if (key.type === ClassicSectorKey.KeyType.A || key.type === ClassicSectorKey.KeyType.UNKNOWN) {
+    override suspend fun authenticate(sectorIndex: Int, key: ClassicSectorKey): Boolean = wrapAndroidExceptions {
+        if (key.key.size != 6)
+            false
+        else if (key.type === ClassicSectorKey.KeyType.A || key.type === ClassicSectorKey.KeyType.UNKNOWN) {
             tech.authenticateSectorWithKeyA(sectorIndex, key.key.dataCopy)
         } else
             tech.authenticateSectorWithKeyB(sectorIndex, key.key.dataCopy)
@@ -45,7 +47,7 @@ class ClassicCardTechAndroid(private val tech: MifareClassic,
 
     override val sectorCount = tech.sectorCount
 
-    override fun readBlock(block: Int): ImmutableByteArray = wrapAndroidExceptions {
+    override suspend fun readBlock(block: Int): ImmutableByteArray = wrapAndroidExceptions {
         try {
             tech.readBlock(block).toImmutable()
         } catch (e: TagLostException) {

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -2243,8 +2243,6 @@
     <!-- Translators: message in scanning dialog on iOS. -->
     <string name="ios_nfcreader_tap">Tap your card</string>
     <string name="ios_nfcreader_exception">Got exception: %s</string>
-    <!-- Currectly only on iOS but to be backported to Android. -->
-    <string name="mifare_plus_not_supported">Mifare Plus is not suppored</string>
     <string name="ios_unknown_mifare">Unknown Mifare: %s</string>
     <string name="ios_unknown_tag">Unknown tag type: %s</string>
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -319,6 +319,7 @@
     <string name="saving_card">Saving card…</string>
 
     <string name="mfc_reading">Reading MIFARE Classic card…</string>
+    <string name="mfp_reading">Reading MIFARE Plus card…</string>
     <string name="mfc_have_key">Trying user-supplied key for sector %d…</string>
     <string name="mfc_other_key">Trying alternate user-supplied keys for sector %d…</string>
     <string name="mfc_default_key">Trying well-known keys for sector %d…</string>


### PR DESCRIPTION
Since Mifare plus is essentially a Mifare Classic with a longer key.
It's even possible for some sectors to be in classic and some other in plus mode
This patch treats it as a variant of mifare classic
The transit factory list is split to avoid needlessly iterating through wrong
factories but one factory may be in both lists.