### PR TITLE
proto: Fix compilation error with Java 12

### DIFF
--- a/proto/build.gradle
+++ b/proto/build.gradle
@@ -21,6 +21,11 @@ apply plugin: 'java-library'
 apply plugin: 'com.google.protobuf'
 apply plugin: 'objective-c'
 
+compileJava {
+     sourceCompatibility = JavaVersion.VERSION_1_8
+     targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 dependencies {
     implementation 'com.google.protobuf:protobuf-lite:3.0.1'
 }


### PR DESCRIPTION
Missing bytecode level made the compiler default to highest level which made
android tools choke