### PR TITLE
en1545: Fix null date of birth

### DIFF
--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/en1545/En1545FixedInteger.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/en1545/En1545FixedInteger.kt
@@ -103,8 +103,9 @@ class En1545FixedInteger(private val mName: String, private val mLen: Int) : En1
             return if (sec == 0) null else getEpoch(tz).daySecond(sec / 86400, sec % 86400)
         }
 
-        fun parseDateBCD(date: Int): Timestamp {
-            return Daystamp(NumberUtils.convertBCDtoInteger(date shr 16),
+        fun parseDateBCD(date: Int): Timestamp? {
+            return if (date == 0) null else
+                Daystamp(NumberUtils.convertBCDtoInteger(date shr 16),
                     NumberUtils.convertBCDtoInteger((date shr 8) and 0xff) - 1,
                     NumberUtils.convertBCDtoInteger(date and 0xff))
         }

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/en1545/En1545FixedInteger.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/en1545/En1545FixedInteger.kt
@@ -104,7 +104,7 @@ class En1545FixedInteger(private val mName: String, private val mLen: Int) : En1
         }
 
         fun parseDateBCD(date: Int): Timestamp? {
-            return if (date == 0) null else
+            return if (date <= 0) null else
                 Daystamp(NumberUtils.convertBCDtoInteger(date shr 16),
                     NumberUtils.convertBCDtoInteger((date shr 8) and 0xff) - 1,
                     NumberUtils.convertBCDtoInteger(date and 0xff))

--- a/src/commonTest/kotlin/au/id/micolous/metrodroid/test/En1545Test.kt
+++ b/src/commonTest/kotlin/au/id/micolous/metrodroid/test/En1545Test.kt
@@ -1,0 +1,56 @@
+/*
+ * En1545Test.kt
+ *
+ * Copyright 2019 Michael Farrell <micolous+git@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package au.id.micolous.metrodroid.test
+
+import au.id.micolous.metrodroid.time.Daystamp
+import au.id.micolous.metrodroid.time.MetroTimeZone
+import au.id.micolous.metrodroid.transit.en1545.*
+import au.id.micolous.metrodroid.util.ImmutableByteArray
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class En1545Test {
+    @Test
+    fun testBcdDate() {
+        assertEquals(Daystamp(2011, 11 /* December */, 31),
+            En1545FixedInteger.parseDateBCD(0x20111231))
+        assertEquals(Daystamp(2019, 0 /* January */, 1),
+            En1545FixedInteger.parseDateBCD(0x20190101))
+    }
+
+    @Test
+    fun testInvalidBcdDate() {
+        assertNull(En1545FixedInteger.parseDateBCD(0))
+        assertNull(En1545FixedInteger.parseDateBCD(-1))
+    }
+
+    @Test
+    fun testBcdDateField() {
+        val f = En1545Container(
+            En1545FixedInteger.dateBCD(En1545TransitData.HOLDER_BIRTH_DATE),
+            En1545FixedInteger.dateBCD(En1545TransitData.ENV_APPLICATION_VALIDITY_END))
+        val h = En1545Parser.parse(
+            ImmutableByteArray.fromHex("0000000020110101"), 0, f)
+
+        assertNull(h.getTimeStamp(En1545TransitData.HOLDER_BIRTH_DATE, MetroTimeZone.UTC))
+        assertEquals(Daystamp(2011, 0 /* January */, 1),
+            h.getTimeStamp(En1545TransitData.ENV_APPLICATION_VALIDITY_END, MetroTimeZone.UTC))
+    }
+}


### PR DESCRIPTION
Fix an issue where a `date of birth` field being present but set to 0 would cause an array-out-of-bounds in `Timestamp.YMD`.

(bug introduced in #569)