### PR TITLE
Add tests and documentation for `jvmcli`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,9 @@ jobs:
     # This is run in parallel (debug + dev + release)
     - stage: assemble and unit test
       env: TARGET=jvm
-      script: ./gradlew :jvmcli:shadowJar jvmCliTest --stacktrace
+      script:
+        - ./gradlew :jvmcli:installShadowDist jvmCliTest --stacktrace
+        - ./.travis/jvmcli_test.sh
     - env: TARGET=android
       script: ./gradlew assembleDebug testDebugUnitTest --stacktrace
     - env: TARGET=android

--- a/.travis/jvmcli_test.sh
+++ b/.travis/jvmcli_test.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Run test on metrodroid-cli
+# This is intended to only check that our CLI still works. Complete card handling tests are in
+# commonTest.
+
+# Exit on any non-zero return, verbose output
+set -ev
+TEST_OUTPUT_DIR=$(mktemp -d)
+
+# Runs Metrodroid, immediately exiting if it fails.
+function check_metrodroid {
+    ./jvmcli/build/install/jvmcli-shadow/bin/metrodroid-cli "$@" || exit 1
+}
+
+# Checks that we got something looking like help output.
+function check_help {
+    check_metrodroid "$@" | grep -q "Commands:"
+}
+
+# Checking help output
+check_help
+check_help -h
+check_help --help
+
+# Supported card count
+check_metrodroid supported | grep -ic "card name"
+
+
+# Test opal-transit-litter.xml
+F="./src/commonTest/assets/opal/opal-transit-litter.xml"
+
+# Should get no output here
+UNRECOGNIZED="$(check_metrodroid unrecognized $F)"
+[[ -z "${UNRECOGNIZED}" ]]
+
+# Check identify
+IDENTIFY_FN="${TEST_OUTPUT_DIR}/identify"
+check_metrodroid identify "$F" > "$IDENTIFY_FN"
+
+# Show output for debug
+cat "$IDENTIFY_FN"
+
+grep -q "Opal" "$IDENTIFY_FN"
+grep -q "3085 2200 7856 2242" "$IDENTIFY_FN"
+
+# Check parse
+PARSE_FN="${TEST_OUTPUT_DIR}/parse"
+check_metrodroid parse "$F" > "$PARSE_FN"
+
+# Show output for debug
+cat "$PARSE_FN"
+
+grep -q "Opal" "$PARSE_FN"
+grep -q "3085 2200 7856 2242" "$PARSE_FN"
+grep -q "Journey completed (distance fare)" "$PARSE_FN"
+
+rm -fr "${TEST_OUTPUT_DIR}"
+
+# Finished!

--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ This software and it's authors are not associated with any public transit agency
    [If you get an error from Gradle about `:material-design-icons` not being available, then your
    clone doesn't have the submodules.](https://github.com/metrodroid/metrodroid/issues/32)
 
+   ZIP source code downloads from GitHub's web interface **will not work**!
+
 2. Import the directory into Android Studio.
 
    Android Studio will prompt you to install the appropriate SDK version, build tools, and Gradle.

--- a/jvmcli/README.md
+++ b/jvmcli/README.md
@@ -1,0 +1,95 @@
+# Metrodroid JVM (CLI)
+
+This contains build rules for a command-line version of Metrodroid's card parser that runs on a
+regular JRE (Java Runtime Environment).
+
+**This is interface is highly experimental, and subject to change!**
+
+## Features
+
+* Identifies and parses Metrodroid JSON, XML and ZIP files
+* Lists supported cards
+
+**Note:** This does not yet have a GUI, support NFC hardware or localization.
+
+## Requirements
+
+* [OpenJDK 9][openjdk9] ([OpenJDK 11 recommended][openjdk11])
+* Android SDK (for building only; will be removed in future)
+* `git`
+
+Like the rest of Metrodroid, you [must `git clone --recursive` (with submodules)][main-readme], or
+**the build will fail**.
+
+**Note:** [The Android SDK tools use APIs that are deprecated and disabled in OpenJDK 9, and deleted
+in OpenJDK 11][android-java-11].
+
+## Building and running tests
+
+The build process uses [Shadow][] [application targets][shadow-app].
+
+From the root of Metrodroid's source directory, run:
+
+```sh
+./gradlew :jvmcli:installShadowDist jvmCliTest
+```
+
+This will "install" to `./jvmcli/build/install/jvmcli-shadow/`.
+
+## Using and running
+
+You can start Metrodroid with `./jvmcli/build/install/jvmcli-shadow/bin/metrodroid-cli`.  You can
+create a shell alias or symlink to it, and that'll still work.
+
+<dl>
+
+<dt><code>metrodroid-cli --help</code></dt>
+<dd>Shows the current in-built help file</dd>
+
+<dt><code>metrodroid-cli identify file.json</code></dt>
+<dd>Identifies the card(s) in <code>file.json</code>.</dd>
+
+<dt><code>metrodroid-cli parse file.json</code></dt>
+<dd>Parses all card(s) information from <code>file.json</code>.</dd>
+
+<dt><code>metrodroid-cli unrecognized file.json</code></dt>
+<dd>Lists all unsupported or unrecognized cards in <code>file.json</code>.</dd>
+
+<dt><code>metrodroid-cli supported</code></dt>
+<dd>Lists all supported cards in this build of Metrodroid.</dd>
+
+</dl>
+
+There are card dump JSON and XML files in `./src/commonTest/assets/`, which can be used to try it
+out:
+
+```
+$ metrodroid-cli identify src/commonTest/assets/opal/opal-transit-litter.xml
+card UID = <04512492b23a80>
+   name = Opal
+   serial = 3085 2200 7856 2242
+
+$ ./metrodroid-cli parse src/commonTest/assets/opal/opal-transit-litter.xml
+card UID = <04512492b23a80>
+   name = Opal
+   serial = 3085 2200 7856 2242
+   balance = -$1.82
+   info
+      General: null
+      Weekly trips: 2
+      Last transaction: null
+      Transaction counter: 21
+      Date: 27 July 2015
+      Time: 6:24:00 pm
+      Vehicle type: Rail
+      Transaction type: Journey completed (distance fare)
+   raw
+      Checksum: 12644
+```
+
+[android-java-11]: https://issuetracker.google.com/issues/67495440
+[main-readme]: ../README.md
+[openjdk9]: https://jdk.java.net/9/
+[openjdk11]: https://jdk.java.net/11/
+[shadow]: https://imperceptiblethoughts.com/shadow/
+[shadow-app]: https://imperceptiblethoughts.com/shadow/application-plugin/

--- a/jvmcli/build.gradle
+++ b/jvmcli/build.gradle
@@ -34,6 +34,7 @@ buildscript {
 
 apply plugin: 'java'
 apply plugin: 'kotlin'
+apply plugin: 'application'
 apply plugin: 'com.github.johnrengelman.shadow'
 
 dependencies {
@@ -43,11 +44,8 @@ dependencies {
     compile group: 'net.sf.kxml', name: 'kxml2', version: '2.3.0'
 }
 
-jar {
-    manifest {
-        attributes 'Main-Class': 'au.id.micolous.metrodroid.CliKt'
-    }
-}
+mainClassName = 'au.id.micolous.metrodroid.CliKt'
+applicationName = 'metrodroid-cli'
 
 repositories {
     mavenCentral()
@@ -63,4 +61,9 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 // workaround for https://youtrack.jetbrains.com/issue/KT-27170
 configurations {
     compileClasspath
+}
+
+tasks.withType(AbstractArchiveTask) {
+    preserveFileTimestamps = false
+    reproducibleFileOrder = true
 }


### PR DESCRIPTION
* Add documentation with worked examples for `jvmCli`
* Use Shadow's application plugin for `jvmCli`
* Build `jvmCli` hermetically
* Adds a script into the Travis configuration to run `jvmCli` with basic integration test on Opal data
* Adds a note that ZIP downloads won't work
