### PR TITLE
Fix possible crash with TypefaceSpan on pre-P devices

### DIFF
--- a/src/main/java/au/id/micolous/metrodroid/multi/FormattedString.kt
+++ b/src/main/java/au/id/micolous/metrodroid/multi/FormattedString.kt
@@ -108,10 +108,15 @@ actual class FormattedStringBuilder {
     }
 
     private fun duplicateSpan(span: Any): Any {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            when (span) {
+                is TypefaceSpan -> return TypefaceSpan(span.typeface ?: return span)
+            }
+        }
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             when (span) {
                 is LocaleSpan -> return LocaleSpan(span.locales)
-                is TypefaceSpan -> return TypefaceSpan(span.typeface ?: return span)
             }
         }
 
@@ -130,7 +135,7 @@ actual class FormattedStringBuilder {
         }
     }
 
-    // Android interface dosn't allow the same object to be spanned
+    // Android interface doesn't allow the same object to be spanned
     // several times in the same string. So if we copy 2 different parts of
     // same input string only first copy preserves any common spans.
     // To overcome this we duplicate the spans before passing


### PR DESCRIPTION
[`TypefaceSpan.getTypeface()` is only available on API 28](https://developer.android.com/reference/android/text/style/TypefaceSpan.html?hl=en#getTypeface()).

I don't think we ever actually use the `typeface` parameter -- and I'm not sure if it is non-null if we set `fontFamily` instead.