### PR TITLE
Android: Add language override to simplify debugging and multicultura…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -376,6 +376,7 @@ android {
         versionName "git -C ${projectDir} describe --always --tags --dirty".execute().text.trim().replaceAll("^v", "")
 
         resConfigs (androidLanguageList)
+        buildConfigField "String[]", "AVAILABLE_TRANSLATIONS", "new String[]{\""+androidLanguageList.join("\", \"")+"\"}"
         vectorDrawables {
             useSupportLibrary = true
             generatedDensities 'ldpi', 'mdpi', 'hdpi'
@@ -391,6 +392,7 @@ android {
     buildTypes {
         debug {
             pseudoLocalesEnabled true
+            buildConfigField "String[]", "AVAILABLE_TRANSLATIONS", "new String[]{\""+androidLanguageList.join("\", \"")+"\", \"en-rXA\", \"ar-rXB\"}"
         }
         dev.initWith(buildTypes.debug)
         dev {

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/CardInfoRegistry.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/CardInfoRegistry.kt
@@ -9,7 +9,7 @@ import au.id.micolous.metrodroid.card.ksx6924.KSX6924Registry
 import au.id.micolous.metrodroid.card.ultralight.UltralightTransitRegistry
 import au.id.micolous.metrodroid.transit.emv.EmvTransitFactory
 import au.id.micolous.metrodroid.transit.ezlink.EZLinkTransitFactory
-import au.id.micolous.metrodroid.util.Collator
+import au.id.micolous.metrodroid.util.collatedBy
 
 object CardInfoRegistry {
     val allFactories = ClassicCardFactoryRegistry.allFactories +
@@ -25,10 +25,5 @@ object CardInfoRegistry {
     val allCards = allFactories.flatMap { it.allCards }
 
     val allCardsAlphabetical: List<CardInfo>
-        get () {
-            val collator = Collator.collator
-            return allCards.sortedWith(Comparator { a, b ->
-                collator.compare(a.name, b.name)
-            })
-        }
+        get () = allCards.collatedBy { it.name }
 }

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/util/Collator.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/util/Collator.kt
@@ -3,3 +3,12 @@ package au.id.micolous.metrodroid.util
 expect object Collator {
     val collator: Comparator<in String>
 }
+
+inline fun <T> Iterable<T>.collatedBy(
+    crossinline selector: (T) -> String
+): List<T> {
+    val collator = Collator.collator
+    return this.sortedWith(Comparator { a, b ->
+        collator.compare(selector(a), selector(b))
+    })
+}

--- a/src/main/java/au/id/micolous/metrodroid/MetrodroidApplication.kt
+++ b/src/main/java/au/id/micolous/metrodroid/MetrodroidApplication.kt
@@ -21,11 +21,14 @@
 package au.id.micolous.metrodroid
 
 import android.app.Application
+import android.content.Context
 import android.os.StrictMode
 import androidx.preference.PreferenceManager
 import androidx.appcompat.app.AppCompatDelegate
 
 import au.id.micolous.farebot.R
+import au.id.micolous.metrodroid.util.Preferences
+import au.id.micolous.metrodroid.util.Utils
 
 class MetrodroidApplication : Application() {
     init {
@@ -42,6 +45,15 @@ class MetrodroidApplication : Application() {
                 .detectAll()
                 .penaltyLog()
                 .build())
+    }
+
+    override fun attachBaseContext(base: Context) {
+        // Do not use Preferences.langOverride as it relies on app context
+        // and it has not been inited yet
+        val prefs = PreferenceManager.getDefaultSharedPreferences(base)
+        val v = prefs.getString(Preferences.PREF_LANG_OVERRIDE, "") ?: ""
+        val locale = Utils.effectiveLocale(v)
+        super.attachBaseContext(Utils.languageContext(base, locale))
     }
 
     companion object {

--- a/src/main/java/au/id/micolous/metrodroid/activity/MetrodroidActivity.kt
+++ b/src/main/java/au/id/micolous/metrodroid/activity/MetrodroidActivity.kt
@@ -24,12 +24,21 @@ import android.os.Bundle
 
 import au.id.micolous.farebot.R
 import au.id.micolous.metrodroid.util.Preferences
+import au.id.micolous.metrodroid.util.Utils
+import android.content.Context
 
 abstract class MetrodroidActivity : AppCompatActivity() {
     private var mAppliedTheme: Int = 0
+    private var mAppliedLang: String = ""
 
     protected open val themeVariant: Int?
         get() = null
+
+    override fun attachBaseContext(base: Context) {
+        val locale = Utils.effectiveLocale()
+        mAppliedLang = locale
+        super.attachBaseContext(Utils.languageContext(base, locale))
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         val variant = themeVariant
@@ -46,6 +55,8 @@ abstract class MetrodroidActivity : AppCompatActivity() {
         } else
             theme = baseTheme
         setTheme(theme)
+        if (mAppliedLang != "")
+            Utils.resetActivityTitle(this)
         super.onCreate(savedInstanceState)
     }
 
@@ -60,7 +71,7 @@ abstract class MetrodroidActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
 
-        if (chooseTheme() != mAppliedTheme)
+        if (chooseTheme() != mAppliedTheme || Utils.effectiveLocale() != mAppliedLang)
             recreate()
     }
 

--- a/src/main/java/au/id/micolous/metrodroid/multi/Localizer.kt
+++ b/src/main/java/au/id/micolous/metrodroid/multi/Localizer.kt
@@ -35,6 +35,7 @@ import au.id.micolous.metrodroid.MetrodroidApplication
 import au.id.micolous.metrodroid.util.Preferences
 import au.id.micolous.metrodroid.ui.HiddenSpan
 import androidx.annotation.VisibleForTesting
+import au.id.micolous.metrodroid.util.Utils
 import java.util.*
 
 import java.util.Locale
@@ -83,16 +84,7 @@ actual object Localizer : LocalizerInterface {
 
     private val englishResources: Resources by lazy {
         val context = MetrodroidApplication.instance
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-            var conf = context.resources.configuration
-            conf = Configuration(conf)
-            conf.setLocale(Locale.ENGLISH)
-            val localizedContext = context.createConfigurationContext(conf)
-            localizedContext.resources
-        } else {
-            // Whatever, keep it translated as fallback
-            context.resources
-        }
+        Utils.localeContext(context, Locale.ENGLISH).resources
     }
 
     fun englishString(res: StringResource, vararg v: Any?): String = englishResources.getString(res, *v)

--- a/src/main/java/au/id/micolous/metrodroid/util/Preferences.kt
+++ b/src/main/java/au/id/micolous/metrodroid/util/Preferences.kt
@@ -50,6 +50,7 @@ actual object Preferences {
     private const val PREF_CONVERT_TIMEZONES = "pref_convert_timezones"
     private const val PREF_RAW_LEVEL = "pref_raw_level"
     const val PREF_THEME = "pref_theme"
+    const val PREF_LANG_OVERRIDE = "pref_lang_override"
     @VisibleForTesting
     const val PREF_SHOW_LOCAL_AND_ENGLISH = "pref_show_local_and_english"
     @VisibleForTesting
@@ -59,7 +60,8 @@ actual object Preferences {
     private const val PREF_MAP_TILE_SUBDOMAINS = "pref_map_tile_subdomains"
     private const val PREF_MAP_TILELAYER_DOCS = "pref_map_tilelayer_docs"
 
-    val PREFS_ANDROID_17 = arrayOf(PREF_MAP_TILE_SUBDOMAINS, PREF_MAP_TILE_URL, PREF_MAP_TILELAYER_DOCS)
+    val PREFS_ANDROID_17 = arrayOf(PREF_MAP_TILE_SUBDOMAINS, PREF_MAP_TILE_URL,
+            PREF_MAP_TILELAYER_DOCS, PREF_LANG_OVERRIDE)
 
     val PREFS_ANDROID_21 = arrayOf(PREF_LOCALISE_PLACES, PREF_LOCALISE_PLACES_HELP)
 
@@ -151,4 +153,6 @@ actual object Preferences {
 
     actual val rawLevel: TransitData.RawLevel get() = TransitData.RawLevel.fromString(getStringPreference(PREF_RAW_LEVEL,
             TransitData.RawLevel.NONE.toString())) ?: TransitData.RawLevel.NONE
+
+    val overrideLang get() = getStringPreference(PREF_LANG_OVERRIDE, "")
 }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -313,6 +313,11 @@
     -->
     <string name="localise_places_longdesc">Text-to-speech voices normally only work well for one language.\n\nLocaleSpan hints are used to mark text as being in a different language. When applied to a station, stop, line or route name, a screen reader that supports these hints will pronounce the name using synthesized voices from the place\'s native language, rather than the language you have configured Android to use.\n\nEnabling this option generally improves the pronunciation of foreign place names that are not internationally renowned, but you might find it more difficult to understand.\n\nThis does not normally change the on-screen display of place names, but some devices may use a different font.\n\nThis requires accessibility software that supports the LocaleSpan API (such as Google TalkBack), and that you have appropriate voices installed.</string>
 
+    <string name="lang_override">Language override</string>
+    <string name="lang_override_desc">Override the application language. Needs application restart to apply</string>
+    <!-- Translators: use system language for app language. -->
+    <string name="lang_default">System default</string>
+
     <!-- Translators: This is shown when an unsupported type of card is scanned, and that we were unable to read it at all, let alone parse its content. -->
     <string name="unsupported_tag">Unsupported NFC card media</string>
 

--- a/src/main/res/xml/prefs.xml
+++ b/src/main/res/xml/prefs.xml
@@ -167,6 +167,12 @@
                     android:entries="@array/raw_levels"
                     android:entryValues="@array/raw_levels_values"
             />
+
+            <ListPreference
+                    android:key="pref_lang_override"
+                    android:title="@string/lang_override"
+                    android:summary="@string/lang_override_desc"
+            />
         </PreferenceCategory>
 
         <PreferenceCategory android:title="@string/obfuscation_title">


### PR DESCRIPTION
…l users

This has 3 motivations:

1. Debugging. Changing system language just to test metrodroid language is cumbersome
2. Multi-cultural users often want to configure language per-app
3. Feature parity: iOS allows it through in-built mechanism, this extends it to
   Android as well

iOS doc isn't changed as iOS has this feature natively