### PR TITLE
collapsed_header: Flip on RTL layouts

### DIFF
--- a/native/metrodroid/metrodroid/Assets.xcassets/collapsed_header.imageset/Contents.json
+++ b/native/metrodroid/metrodroid/Assets.xcassets/collapsed_header.imageset/Contents.json
@@ -3,11 +3,13 @@
     {
       "idiom" : "universal",
       "filename" : "ic_chevron_right_18pt.png",
+      "language-direction" : "left-to-right",
       "scale" : "1x"
     },
     {
       "idiom" : "universal",
       "filename" : "ic_chevron_right_18pt-1.png",
+      "language-direction" : "left-to-right",
       "appearances" : [
         {
           "appearance" : "luminosity",
@@ -19,6 +21,7 @@
     {
       "idiom" : "universal",
       "filename" : "ic_chevron_right_white_18pt.png",
+      "language-direction" : "left-to-right",
       "appearances" : [
         {
           "appearance" : "luminosity",
@@ -30,11 +33,13 @@
     {
       "idiom" : "universal",
       "filename" : "ic_chevron_right_18pt_2x.png",
+      "language-direction" : "left-to-right",
       "scale" : "2x"
     },
     {
       "idiom" : "universal",
       "filename" : "ic_chevron_right_18pt_2x-1.png",
+      "language-direction" : "left-to-right",
       "appearances" : [
         {
           "appearance" : "luminosity",
@@ -46,6 +51,7 @@
     {
       "idiom" : "universal",
       "filename" : "ic_chevron_right_white_18pt_2x.png",
+      "language-direction" : "left-to-right",
       "appearances" : [
         {
           "appearance" : "luminosity",
@@ -57,11 +63,13 @@
     {
       "idiom" : "universal",
       "filename" : "ic_chevron_right_18pt_3x.png",
+      "language-direction" : "left-to-right",
       "scale" : "3x"
     },
     {
       "idiom" : "universal",
       "filename" : "ic_chevron_right_18pt_3x-1.png",
+      "language-direction" : "left-to-right",
       "appearances" : [
         {
           "appearance" : "luminosity",
@@ -73,6 +81,7 @@
     {
       "idiom" : "universal",
       "filename" : "ic_chevron_right_white_18pt_3x.png",
+      "language-direction" : "left-to-right",
       "appearances" : [
         {
           "appearance" : "luminosity",


### PR DESCRIPTION
In RTL languages the arrow ends up pointing towards the
string rather than away. So mark it as needing a flip on
RTL languages.

Android is not affected due to different design