### PR TITLE
iOS: Remove metrodroid registration as "Open with" target

### DIFF
--- a/native/metrodroid/metrodroid/Info.plist
+++ b/native/metrodroid/metrodroid/Info.plist
@@ -6,31 +6,6 @@
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
 	<string>Metrodroid</string>
-	<key>CFBundleDocumentTypes</key>
-	<array>
-		<dict>
-			<key>CFBundleTypeName</key>
-			<string>Metrodroid zip</string>
-			<key>CFBundleTypeRole</key>
-			<string>Viewer</string>
-			<key>LSItemContentTypes</key>
-			<array>
-				<string>public.zip-archive</string>
-			</array>
-		</dict>
-		<dict>
-			<key>CFBundleTypeIconFiles</key>
-			<array/>
-			<key>CFBundleTypeName</key>
-			<string>Metrodroid json</string>
-			<key>CFBundleTypeRole</key>
-			<string>Viewer</string>
-			<key>LSItemContentTypes</key>
-			<array>
-				<string>public.json</string>
-			</array>
-		</dict>
-	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
I was under mistaken impression that document picker didn't exist on iOS.
Hence I registered Metrodroid as a reader for zip and json. As
document picker does exist and now we use it and we're not a real viewer for
either of formats, it is probably better not to pollute "share with" selection
and that decreases probability that someone tries to open unrelated zip or
unrelated json with us leading to unexpected results.

This also makes it closes to Android