### PR TITLE
roll forward dependency versions; externalise some dep versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,9 @@ buildscript {
         build_version = '29.0.0'
         android_sdk_version = 29
         android_min_version = 16
+        android_gradle_version = '3.4.1'
+        protobuf_version = '3.10.0-rc-1'
+        protobuf_gradle_version = '0.8.10'
     }
     repositories {
         google()
@@ -27,8 +30,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.8'
+        classpath "com.android.tools.build:gradle:$android_gradle_version"
+        classpath "com.google.protobuf:protobuf-gradle-plugin:$protobuf_gradle_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.8.6'
@@ -217,7 +220,7 @@ dependencies {
     implementation "androidx.cardview:cardview:1.0.0"
     implementation "androidx.annotation:annotation:1.0.0"
     implementation "androidx.preference:preference:1.0.0"
-    implementation 'com.google.protobuf:protobuf-lite:3.0.1'
+    implementation "com.google.protobuf:protobuf-javalite:$protobuf_version"
     implementation project(':leaflet')
     implementation project(':material-design-icons')
     implementation project(':proto')
@@ -376,7 +379,7 @@ kotlin {
                 implementation 'commons-io:commons-io:2.5'
                 implementation 'org.apache.commons:commons-lang3:3.5'
                 implementation "org.jetbrains.kotlinx:kotlinx-io-jvm:$kotlinio_version"
-                implementation 'com.google.protobuf:protobuf-lite:3.0.1'
+                implementation "com.google.protobuf:protobuf-javalite:$protobuf_version"
                 implementation 'com.github.ajalt:clikt:2.1.0'
                 implementation group: 'xmlpull', name: 'xmlpull', version: '1.1.3.4a'
                 implementation project(':proto')

--- a/jvmcli/build.gradle
+++ b/jvmcli/build.gradle
@@ -9,26 +9,17 @@ allprojects {
 }
 
 buildscript {
-    ext {
-        kotlin_version = '1.3.11'
-        lint_version = '26.2.1'
-        support_version = '28.0.0'
-        android_test_version = '1.1.0'
-        build_version = '28.0.3'
-        android_sdk_version = 28
-        android_min_version = 16
-    }
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.6'
+        classpath "com.android.tools.build:gradle:$android_gradle_version"
+        classpath "com.google.protobuf:protobuf-gradle-plugin:$protobuf_gradle_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
-	classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.3'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.3'
     }
 }
 

--- a/proto/build.gradle
+++ b/proto/build.gradle
@@ -13,7 +13,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.8'
+        classpath "com.google.protobuf:protobuf-gradle-plugin:$protobuf_gradle_version"
     }
 }
 
@@ -27,29 +27,22 @@ compileJava {
 }
 
 dependencies {
-    implementation 'com.google.protobuf:protobuf-lite:3.0.1'
+    implementation "com.google.protobuf:protobuf-javalite:$protobuf_version"
 }
 
 protobuf {
     protoc {
         // You still need protoc like in the non-Android case
-        artifact = 'com.google.protobuf:protoc:3.7.1'
-    }
-    plugins {
-        javalite {
-            // The codegen for lite comes as a separate artifact
-            artifact = 'com.google.protobuf:protoc-gen-javalite:3.0.0'
-        }
+        artifact = "com.google.protobuf:protoc:$protobuf_version"
     }
     generateProtoTasks {
         all().each { task ->
             task.builtins {
-                // In most cases you don't need the full Java output
-                // if you use the lite output.
-                remove java
+                java {
+                    option "lite"
+                }
             }
             task.plugins {
-                javalite { }
                 objc {}
             }
         }


### PR DESCRIPTION
Update some dependencies, and make versioning consistent again:

* Kotlin 1.3.11 (jvmcli) / 1.3.41 (others) ▶️ ~1.3.50~ 1.3.41 (consistently)
* Android Gradle Plugin 3.2.1 (jvmcli) / 3.4.1 (others) ▶️ 3.4.1 (consistently)
* Protobuf 3.0.1 ▶️ 3.9.1 (consistently); [switched to new JavaLite configuration style used in Protobuf 3.8.0+](https://github.com/google/protobuf-gradle-plugin#default-outputs)
* Protobuf Gradle Plugin 0.8.6 (jvmcli) / 0.8.8 (others) ▶️ 0.8.10 (consistently)

Removes duplicated definitions of `buildscript.ext` in `jvmcli/build.gradle`.

Some stuff here is still behind the current version -- the key things I was going for was making `jvmcli/build.gradle` consistent, and getting [one of the illegal reflective access issues](https://github.com/protocolbuffers/protobuf/issues/3781) fixed ([as seen here](https://travis-ci.org/metrodroid/metrodroid/jobs/585550776#L505-L510)).