### PR TITLE
octopus: Fix transition date; add month enum

### DIFF
--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/time/Timestamp.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/time/Timestamp.kt
@@ -175,12 +175,37 @@ private val monthToDays = listOf(0, 31, 59, 90, 120, 151, 181,
         212, 243, 273, 304, 334)
 
 /**
+ * Enum of 0-indexed months in the Gregorian calendar
+ */
+@Suppress("unused")
+enum class Month(val m: Int) {
+    JANUARY(0),
+    FEBRUARY(1),
+    MARCH(2),
+    APRIL(3),
+    MAY(4),
+    JUNE(5),
+    JULY(6),
+    AUGUST(7),
+    SEPTEMBER(8),
+    OCTOBER(9),
+    NOVEMBER(10),
+    DECEMBER(11);
+
+    /** Converts a month to a 0-indexed month */
+    fun toInt() : Int { return m; }
+}
+
+/**
  * Represents a year, month and day in the Gregorian calendar.
  *
  * @property month Month, where January = 0.
  * @property day Day of the month, where the first day of the month = 1.
  */
 data class YMD(val year: Int, val month: Int, val day: Int) {
+    @Suppress("unused")
+    constructor(year: Int, month: Month, day: Int) : this(year, month.m, day)
+
     val daysSinceEpoch: Int get() {
         val ym = 12 * year + month
         var y: Int = ym / 12
@@ -431,6 +456,13 @@ data class TimestampFull internal constructor(val timeInMillis: Long,
             timeInMillis = epochDayHourMinToMillis(
                     tz, YMD(year, month, day).daysSinceEpoch, hour, min) + sec * SEC,
             tz = tz
+    )
+
+    constructor(tz : MetroTimeZone, year: Int, month: Month, day: Int, hour: Int,
+                min: Int, sec: Int = 0) : this(
+        year = year, month = month.m, day = day,
+        hour = hour, min = min, sec = sec,
+        tz = tz
     )
 
     constructor(tz: MetroTimeZone, dhm: DHM) : this(

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/octopus/OctopusData.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/octopus/OctopusData.kt
@@ -19,6 +19,7 @@
 package au.id.micolous.metrodroid.transit.octopus
 
 import au.id.micolous.metrodroid.time.MetroTimeZone
+import au.id.micolous.metrodroid.time.Month
 import au.id.micolous.metrodroid.time.TimestampFull
 
 class OctopusData {
@@ -26,12 +27,14 @@ class OctopusData {
         val OCTOPUS_TZ = MetroTimeZone.BEIJING
 
         private val OCTOPUS_OFFSETS = listOf(
-                TimestampFull(year = 1997, month = 0, day = 1, hour = 0, min = 0, tz = OCTOPUS_TZ) to 350,
+                TimestampFull(OCTOPUS_TZ,
+                    1997, Month.JANUARY, 1, 0, 0) to 350,
 
-                // Negative balance amount changes, which changes the offset:
+                // Negative balance amount change effective 2017-10-01, which changes the offset:
                 // https://www.octopus.com.hk/en/consumer/customer-service/faq/get-your-octopus/about-octopus.html#3532
                 // https://www.octopus.com.hk/en/consumer/customer-service/faq/get-your-octopus/about-octopus.html#3517
-                TimestampFull(year = 2017, month = 10, day = 1, hour = 0, min = 0, tz = OCTOPUS_TZ) to 500
+                TimestampFull(OCTOPUS_TZ,
+                    2017, Month.OCTOBER, 1, 0, 0) to 500
         )
 
         private const val SHENZHEN_OFFSET = 350

--- a/src/commonTest/kotlin/au/id/micolous/metrodroid/test/OctopusTest.kt
+++ b/src/commonTest/kotlin/au/id/micolous/metrodroid/test/OctopusTest.kt
@@ -24,6 +24,7 @@ import au.id.micolous.metrodroid.card.felica.FelicaCard
 import au.id.micolous.metrodroid.card.felica.FelicaService
 import au.id.micolous.metrodroid.card.felica.FelicaSystem
 import au.id.micolous.metrodroid.time.MetroTimeZone
+import au.id.micolous.metrodroid.time.Month
 import au.id.micolous.metrodroid.time.TimestampFull
 import au.id.micolous.metrodroid.transit.TransitCurrency
 import au.id.micolous.metrodroid.transit.octopus.OctopusTransitData
@@ -70,8 +71,10 @@ class OctopusTest : BaseInstrumentedTest() {
 
     @Test
     fun test2018Card() {
+        // This data is from a card last used in 2018, but we've adjusted the date here to
+        // 2017-10-02 to test the behaviour of OctopusData.getOctopusOffset.
         val c = octopusCardFromHex("00000164000000000000000000000021",
-                TimestampFull(year = 2019, month = 0, day = 1, hour = 0, min = 0, tz = MetroTimeZone.BEIJING))
+                TimestampFull(MetroTimeZone.UTC, 2017, Month.OCTOBER, 2, 0, 0))
 
         checkCard(c, TransitCurrency.HKD(-1440))
     }
@@ -79,7 +82,7 @@ class OctopusTest : BaseInstrumentedTest() {
     @Test
     fun test2016Card() {
         val c = octopusCardFromHex("000001520000000000000000000086B1",
-                TimestampFull(year = 2016, month = 0, day = 1, hour = 0, min = 0, tz = MetroTimeZone.BEIJING))
+            TimestampFull(MetroTimeZone.UTC, 2016, Month.JANUARY, 1, 0, 0))
 
         checkCard(c, TransitCurrency.HKD(-120))
     }


### PR DESCRIPTION
This was 2017-11-01 before, when it should actually be 2017-10-01.

This also adds a `Month` enum to `Timestamp`, to make it easier to avoid this issue.