### PR TITLE
Change file import to use the same code as key import on pre-Kitkat

### DIFF
--- a/src/main/java/au/id/micolous/metrodroid/fragment/KeysFragment.kt
+++ b/src/main/java/au/id/micolous/metrodroid/fragment/KeysFragment.kt
@@ -31,7 +31,6 @@ import android.database.MergeCursor
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
-import android.os.Environment
 import android.util.Log
 import android.view.*
 import android.widget.*
@@ -199,23 +198,8 @@ class KeysFragment : ListFragment(), AdapterView.OnItemLongClickListener {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == R.id.add_key) {
-            val uri = Uri.fromFile(Environment.getExternalStorageDirectory())
-            val i = Intent(Intent.ACTION_GET_CONTENT)
-            i.putExtra(Intent.EXTRA_STREAM, uri)
-
-            // In Android 4.4 and later, we can say the right thing!
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                i.type = "*/*"
-                val mimetypes = arrayOf("application/json", "application/octet-stream", "application/x-extension-bin")
-                i.putExtra(Intent.EXTRA_MIME_TYPES, mimetypes)
-            } else {
-                // Failsafe, used in the emulator for local files
-                i.type = "application/octet-stream"
-            }
-
-            if (item.itemId == R.id.add_key)
-                startActivityForResult(Intent.createChooser(i, Localizer.localizeString(R.string.select_file)),
-                        REQUEST_SELECT_FILE)
+            val i = Utils.getContentIntent(listOf("application/json", "application/x-extension-bin"))
+            startActivityForResult(i, REQUEST_SELECT_FILE)
             return true
         } else if (item.itemId == R.id.key_more_info) {
             startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://micolous.github.io/metrodroid/key_formats")))

--- a/src/main/java/au/id/micolous/metrodroid/util/Utils.kt
+++ b/src/main/java/au/id/micolous/metrodroid/util/Utils.kt
@@ -29,6 +29,7 @@ import android.content.res.Configuration
 import android.net.Uri
 import android.nfc.NfcAdapter
 import android.os.Build
+import android.os.Environment
 import android.util.Log
 import android.view.View
 import android.view.WindowManager
@@ -241,5 +242,23 @@ object Utils {
         } catch (e: Exception) {
             e.printStackTrace()
         }
+    }
+
+    fun getContentIntent(mimeTypes: List<String>): Intent {
+        val uri = Uri.fromFile(Environment.getExternalStorageDirectory())
+        val i = Intent(Intent.ACTION_GET_CONTENT)
+        i.putExtra(Intent.EXTRA_STREAM, uri)
+        // In Android 4.4 and later, we can say the right thing!
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            i.type = "*/*"
+            i.putExtra(Intent.EXTRA_MIME_TYPES, (mimeTypes + listOf(
+                // Fallback for cases where we didn't get a good mime type from the
+                // OS, this allows most "other" files to be selected.
+                "application/octet-stream")).toTypedArray())
+        } else {
+            // Failsafe, used in the emulator for local files
+            i.type = "application/octet-stream"
+        }
+        return Intent.createChooser(i, Localizer.localizeString(R.string.select_file))
     }
 }


### PR DESCRIPTION
We have 2 different way of handling import on pre-Kitkat:

1. Use hardcoded file name (cards import)
2. Use an intent but different than post-Kitkat one (key import)

So let's settle on one: an intent and merge the code.

I tested it on my Blackberry Q10 that implements android 4.3 VM.