### PR TITLE
Stretch a safety net under rendering of supported card

### DIFF
--- a/src/main/java/au/id/micolous/metrodroid/fragment/CardBalanceFragment.kt
+++ b/src/main/java/au/id/micolous/metrodroid/fragment/CardBalanceFragment.kt
@@ -35,6 +35,7 @@ import au.id.micolous.metrodroid.transit.Subscription
 import au.id.micolous.metrodroid.transit.TransitBalance
 import au.id.micolous.metrodroid.transit.TransitData
 import au.id.micolous.metrodroid.ui.ListItem
+import au.id.micolous.metrodroid.util.Utils
 
 class CardBalanceFragment : ListFragment() {
     private var mTransitData: TransitData? = null
@@ -74,22 +75,14 @@ class CardBalanceFragment : ListFragment() {
         }
 
         private fun getErrorView(convertView: View?, parent: ViewGroup, err: String): View {
-            var view = convertView
-            if (view == null || view.tag !== TAG_ERROR_VIEW) {
-                view = activity?.layoutInflater?.inflate(R.layout.balance_item, parent, false)
-                view!!.tag = TAG_ERROR_VIEW
-            }
+            val view = Utils.loadMultiReuse(convertView, activity?.layoutInflater!!, R.layout.balance_item, parent, false)
 
-            (view.findViewById<View>(R.id.balance) as TextView).text = err
+            view.findViewById<TextView>(R.id.balance).text = err
             return view
         }
 
         fun getSubscriptionView(convertView: View?, parent: ViewGroup, subscription: Subscription): View {
-            var view = convertView
-            if (view == null || view.tag !== TAG_SUBSCRIPTION_VIEW) {
-                view = activity?.layoutInflater?.inflate(R.layout.subscription_item, parent, false)
-                view!!.tag = TAG_SUBSCRIPTION_VIEW
-            }
+            val view = Utils.loadMultiReuse(convertView, activity?.layoutInflater!!, R.layout.subscription_item, parent, false)
 
             val validView = view.findViewById<TextView>(R.id.valid)
             val validity = subscription.formatValidity()
@@ -184,11 +177,7 @@ class CardBalanceFragment : ListFragment() {
 
         private fun getBalanceView(convertView: View?,
                                    parent: ViewGroup, balance: TransitBalance): View {
-            var view = convertView
-            if (view == null || view.tag !== TAG_BALANCE_VIEW) {
-                view = activity?.layoutInflater?.inflate(R.layout.balance_item, parent, false)
-                view!!.tag = TAG_BALANCE_VIEW
-            }
+            var view = Utils.loadMultiReuse(convertView, activity?.layoutInflater!!, R.layout.balance_item, parent, false)
 
             val validView = view.findViewById<TextView>(R.id.valid)
             val validity = TransitBalance.formatValidity(balance)
@@ -271,10 +260,6 @@ class CardBalanceFragment : ListFragment() {
 
     companion object {
         private const val TAG = "CardBalanceFragment"
-
-        private const val TAG_BALANCE_VIEW = "balanceView"
-        private const val TAG_SUBSCRIPTION_VIEW = "subscriptionView"
-        private const val TAG_ERROR_VIEW = "errorView"
 
         internal fun subHasExtraInfo(sub: Subscription): Boolean = Subscription.hasInfo(sub)
 

--- a/src/main/java/au/id/micolous/metrodroid/fragment/SupportedCardsFragment.kt
+++ b/src/main/java/au/id/micolous/metrodroid/fragment/SupportedCardsFragment.kt
@@ -47,6 +47,8 @@ import au.id.micolous.metrodroid.transit.CardInfo
 import au.id.micolous.metrodroid.transit.CardInfoRegistry
 import au.id.micolous.metrodroid.util.DrawableUtils
 import au.id.micolous.metrodroid.util.Preferences
+import au.id.micolous.metrodroid.util.getErrorMessage
+import au.id.micolous.metrodroid.util.Utils
 
 /**
  * @author Eric Butler, Michael Farrell
@@ -103,8 +105,18 @@ class SupportedCardsFragment : ExpandableListFragment() {
         }
 
         override fun getChildView(parent: Int, child: Int, isLast: Boolean, convertViewReuse: View?, viewGroup: ViewGroup): View {
-            val convertView = convertViewReuse ?: mLayoutInflater.inflate(R.layout.supported_card, null)
+            try {
+                return getChildViewReal(parent, child, convertViewReuse)
+            } catch (e: Exception) {
+                val convertView = Utils.loadMultiReuse(convertViewReuse, mLayoutInflater, android.R.layout.simple_list_item_1, null, false)
+                val tv = convertView.findViewById<TextView>(android.R.id.text1)
+                tv.text = getErrorMessage(e)
+                return convertView
+            }
+        }
 
+        private fun getChildViewReal(parent: Int, child: Int, convertViewReuse: View?): View {
+            val convertView = Utils.loadMultiReuse(convertViewReuse, mLayoutInflater, R.layout.supported_card, null, false)
             val info = cards[parent].second[child]
 
             convertView.findViewById<TextView>(R.id.card_name).text = info.name

--- a/src/main/java/au/id/micolous/metrodroid/util/Utils.kt
+++ b/src/main/java/au/id/micolous/metrodroid/util/Utils.kt
@@ -31,7 +31,10 @@ import android.nfc.NfcAdapter
 import android.os.Build
 import android.os.Environment
 import android.util.Log
+import android.view.LayoutInflater
+import android.view.MenuItem
 import android.view.View
+import android.view.ViewGroup
 import android.view.WindowManager
 import android.widget.Toast
 import androidx.annotation.StringRes
@@ -261,5 +264,14 @@ object Utils {
             i.type = "application/octet-stream"
         }
         return Intent.createChooser(i, Localizer.localizeString(R.string.select_file))
+    }
+
+    fun loadMultiReuse(reuseView: View?, inflater: LayoutInflater, resource: Int,
+                       root: ViewGroup?, attachToRoot: Boolean, tag: String = resource.toString(16)): View {
+        if (reuseView != null && reuseView.tag == tag)
+            return reuseView
+        val v = inflater.inflate(resource, root, attachToRoot)
+        v.tag = tag
+        return v
     }
 }


### PR DESCRIPTION
Experience shows that rendering supported card view is especially crash-prone
on older devices. Add a safety net to show an error rather than crash outright.
While on it extract view reuse logic into a separate function