### PR TITLE
travis: limit JVM to 1.5G RAM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,9 @@ env:
     - AVDMANAGER_OPTS="--add-modules java.se.ee"
     - SDKMANAGER_OPTS="--add-modules java.se.ee"
 
+    # Limit RAM usage. Travis has a 4GB limit, we tend to flake otherwise.
+    - JVM_OPTS="-Xms1536M -Xmx1536M -XX:MaxMetaspaceSize=768M -XX:+HeapDumpOnOutOfMemoryError"
+
 jobs:
   include:
     # This only runs "assemble", which compiles the code and runs non-Android unit tests. This is


### PR DESCRIPTION
There have been a few of these lately:

* #650: https://travis-ci.org/metrodroid/metrodroid/jobs/593850496
* #661: https://travis-ci.org/metrodroid/metrodroid/jobs/593925575
* #665: https://travis-ci.org/metrodroid/metrodroid/jobs/593955677

To try to improve the situation, this clamps JVM memory use to 1.5GB, MetaspaceSize to 0.75GB and dumps the heap on OOM.  Travis has a 4GB limit.

This only applies to use on Travis.