### PR TITLE
r8: Use non-deprecated flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,9 @@ env:
     - AVDMANAGER_OPTS="--add-modules java.se.ee"
     - SDKMANAGER_OPTS="--add-modules java.se.ee"
 
+    # Limit RAM usage. Travis has a 4GB limit, we tend to flake otherwise.
+    - JVM_OPTS="-Xms1536M -Xmx1536M -XX:MaxMetaspaceSize=768M -XX:+HeapDumpOnOutOfMemoryError"
+
 jobs:
   include:
     # This only runs "assemble", which compiles the code and runs non-Android unit tests. This is

--- a/build.gradle
+++ b/build.gradle
@@ -550,7 +550,6 @@ android {
             applicationIdSuffix '.dev'
             minifyEnabled true
             shrinkResources true
-            useProguard false
             proguardFiles getDefaultProguardFile('proguard-android.txt'),
                     'proguard.cfg'
             matchingFallbacks = ['debug']
@@ -558,7 +557,6 @@ android {
         release {
             minifyEnabled true
             shrinkResources true
-            useProguard false
             proguardFiles getDefaultProguardFile('proguard-android.txt'),
                     'proguard.cfg'
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 android.useAndroidX=true
 android.enableJetifier=true
+android.enableR8=true
 android.jetifier.blacklist=.*proto\\.jar


### PR DESCRIPTION
Addresses this warning:

```
WARNING: DSL element 'useProguard' is obsolete and will be removed soon.
Use 'android.enableR8' in gradle.properties to switch between R8 and Proguard.
```

To be applied after #670 
