### PR TITLE
ios: fix getMonth usage after PR#647

### DIFF
--- a/src/iOSMain/kotlin/au/id/micolous/metrodroid/time/Timestamp.kt
+++ b/src/iOSMain/kotlin/au/id/micolous/metrodroid/time/Timestamp.kt
@@ -61,7 +61,7 @@ internal actual fun epochDayHourMinToMillis(tz: MetroTimeZone, daysSinceEpoch: I
     val ymd = getYMD(daysSinceEpoch)
     val nstz = metroTz2NS(tz)
     dateComponents.day = ymd.day.toLong()
-    dateComponents.month = ymd.month.toLong() + 1
+    dateComponents.month = ymd.month.oneBasedIndex.toLong()
     dateComponents.year = ymd.year.toLong()
     dateComponents.hour = hour.toLong()
     dateComponents.minute = min.toLong()


### PR DESCRIPTION
#647 changed the way `getMonth` works.  This fixes the use on iOS.