### PR TITLE
ios: Workaround for reading multi-system FeliCa cards (issue #613)

### DIFF
--- a/docs/ios.md
+++ b/docs/ios.md
@@ -60,9 +60,22 @@ Metrodroid for iOS **does not support**:
 
 * **EMV cards**: the EMV protocol requires dynamic AID selection, which is not allowed on iOS.
 
-* **FeliCa cards with more than one system not supported**: [this appears to be an iOS
-  bug][ios-felica]. This impacts Hu Tong Xing (互通行) cards, as well as some Hayakaken, PASMO and
-  Suica cards. ICOCA and nimoca cards both appear fine.
+* **FeliCa cards that use system codes other than the first**: [due to a bug in iOS][ios-felica],
+  Metrodroid on iOS can only read the _first_ system code on a card. Metrodroid on iOS will
+  instead leave empty placeholder system(s) for other system codes -- whereas Metrodroid on Android
+  will try to read the contents of other system codes.
+
+  * **Single-system FeliCa cards** (such as KMT, ICOCA, nimoca and Octopus) are _not_ impacted.
+
+  * **Multi-system [Japan IC][] cards** (such as Hayakaken, PASMO and Suica) will only read system
+    code `0x3`. This is where the payment and ticketing data is stored, so _most users will not see
+    any difference_.
+
+    The FeliCa Networks Common Area (`0xfe00`), and other miscellaneous system codes will not be
+    read; but these cannot be parsed by Metrodroid anyway.
+
+  * **Hu Tong Xing (互通行)** (untested) will probably _only_ read the Octopus (HKD) purse balance,
+    and not the Shenzhen Tong (CNY) purse balance.
 
 * **Leap**: unlocking Leap cards is not implemented.
 
@@ -199,6 +212,7 @@ changes have been removed from `native/metrodroid/metrodroid.xcodeproj/project.p
 [dev-caps]: https://help.apple.com/developer-account/#/dev21218dfd6
 [ios-felica]: https://github.com/metrodroid/metrodroid/issues/613
 [ios-issue]: https://github.com/metrodroid/metrodroid/issues/new?assignees=&labels=bug&template=bug.md&title=%5BBUG%5D
+[Japan IC]: https://github.com/metrodroid/metrodroid/wiki/IC-%28Japan%29
 [signing-workflow]: https://help.apple.com/xcode/mac/current/#/dev60b6fbbc7
 [TestFlight]: https://developer.apple.com/testflight/
 [xcode-setup]: https://help.apple.com/xcode/mac/current/#/devaf282080a

--- a/native/metrodroid/metrodroid/SupportedCardsViewCell.swift
+++ b/native/metrodroid/metrodroid/SupportedCardsViewCell.swift
@@ -54,7 +54,9 @@ class SupportedCardsViewCell: UICollectionViewCell {
     
     func getNoteText(_ ci: CardInfo) -> String? {
         var notes = ""
-        if let li = ci.resourceExtraNote {
+        if let li = ci.iOSExtraNote {
+            notes += Utils.localizeString(li)
+        } else if let li = ci.resourceExtraNote {
             notes += Utils.localizeString(li)
         }
         if (ci.preview) {

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/felica/FelicaCard.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/felica/FelicaCard.kt
@@ -174,8 +174,11 @@ data class FelicaCard(
                     FelicaUtils.getFriendlySystemName(systemCode)))
 
             if (system.services.isEmpty()) {
-                ListItem(title, if (system.skipped) {
-                    "Skipped reading system" } else { "Empty system" })
+                ListItem(title, Localizer.localizeString(if (system.skipped) {
+                    R.string.felica_skipped_system
+                } else {
+                    R.string.felica_empty_system
+                }))
             } else {
                 ListItemRecursive(
                     title,

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/felica/FelicaCard.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/felica/FelicaCard.kt
@@ -2,7 +2,7 @@
  * FelicaCard.kt
  *
  * Copyright 2011 Eric Butler <eric@codebutler.com>
- * Copyright 2016-2018 Michael Farrell <micolous+git@gmail.com>
+ * Copyright 2016-2019 Michael Farrell <micolous+git@gmail.com>
  * Copyright 2019 Google
  *
  * This program is free software: you can redistribute it and/or modify
@@ -168,13 +168,24 @@ data class FelicaCard(
     @Transient
     override val rawData: List<ListItem>
         get() = systems.map { (systemCode, system) ->
-            ListItemRecursive(
-                    Localizer.localizeString(R.string.felica_system_title_format,
-                            systemCode.hexString,
-                            Localizer.localizeString(
-                                    FelicaUtils.getFriendlySystemName(systemCode))),
-                    Localizer.localizePlural(R.plurals.felica_service_count,
-                            system.services.size, system.services.size), system.rawData(systemCode))
+            val title = Localizer.localizeString(R.string.felica_system_title_format,
+                systemCode.hexString,
+                Localizer.localizeString(
+                    FelicaUtils.getFriendlySystemName(systemCode)))
+
+            if (system.services.isEmpty()) {
+                ListItem(title, if (system.skipped) {
+                    "Skipped reading system" } else { "Empty system" })
+            } else {
+                ListItemRecursive(
+                    title,
+                    Localizer.localizePlural(
+                        R.plurals.felica_service_count,
+                        system.services.size, system.services.size
+                    ),
+                    system.rawData(systemCode)
+                )
+            }
         }
 
     /**

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/felica/FelicaService.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/felica/FelicaService.kt
@@ -22,7 +22,6 @@
 package au.id.micolous.metrodroid.card.felica
 
 import au.id.micolous.metrodroid.multi.FormattedString
-import au.id.micolous.metrodroid.serializers.XMLId
 import au.id.micolous.metrodroid.serializers.XMLListIdx
 import au.id.micolous.metrodroid.ui.ListItem
 import au.id.micolous.metrodroid.util.NumberUtils
@@ -33,7 +32,7 @@ data class FelicaService(
     /** Blocks that are part of this Service */
     @XMLListIdx("address") val blocks: List<FelicaBlock> = emptyList(),
     /** When reading, did we skip trying to read the contents of this system? */
-    @XMLId("skipped") val skipped: Boolean = false
+    val skipped: Boolean = false
 ) {
     fun getBlock(idx: Int) = blocks[idx]
 

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/felica/FelicaService.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/felica/FelicaService.kt
@@ -2,6 +2,8 @@
  * FelicaService.kt
  *
  * Copyright 2011 Eric Butler <eric@codebutler.com>
+ * Copyright 2018-2019 Michael Farrell <micolous+git@gmail.com>
+ * Copyright 2018-2019 Google
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,19 +22,22 @@
 package au.id.micolous.metrodroid.card.felica
 
 import au.id.micolous.metrodroid.multi.FormattedString
+import au.id.micolous.metrodroid.serializers.XMLId
 import au.id.micolous.metrodroid.serializers.XMLListIdx
 import au.id.micolous.metrodroid.ui.ListItem
 import au.id.micolous.metrodroid.util.NumberUtils
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.Transient
 
 @Serializable
 data class FelicaService(
-        @XMLListIdx("address")
-        val blocks: List<FelicaBlock>) {
+    /** Blocks that are part of this Service */
+    @XMLListIdx("address") val blocks: List<FelicaBlock> = emptyList(),
+    /** When reading, did we skip trying to read the contents of this system? */
+    @XMLId("skipped") val skipped: Boolean = false
+) {
     fun getBlock(idx: Int) = blocks[idx]
 
-    @Transient
+    /** Shows Blocks inside of this Service */
     val rawData: List<ListItem>
         get() =
             blocks.mapIndexed { blockAddr, (data) ->

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/felica/FelicaSystem.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/felica/FelicaSystem.kt
@@ -22,7 +22,6 @@ package au.id.micolous.metrodroid.card.felica
 
 import au.id.micolous.metrodroid.multi.Localizer
 import au.id.micolous.metrodroid.multi.R
-import au.id.micolous.metrodroid.serializers.XMLId
 import au.id.micolous.metrodroid.serializers.XMLListIdx
 import au.id.micolous.metrodroid.ui.ListItem
 import au.id.micolous.metrodroid.ui.ListItemRecursive
@@ -34,7 +33,7 @@ data class FelicaSystem(
     /** Service codes that are present in this System */
     @XMLListIdx("code") val services: Map<Int, FelicaService> = emptyMap(),
     /** When reading, did we skip trying to read the contents of this system? */
-    @XMLId("skipped") val skipped: Boolean = false) {
+    val skipped: Boolean = false) {
     fun getService(serviceCode: Int) = services[serviceCode]
 
     /** Shows raw data for all Services within this System */

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/felica/FelicaSystem.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/felica/FelicaSystem.kt
@@ -2,6 +2,8 @@
  * FelicaSystem.kt
  *
  * Copyright 2011 Eric Butler <eric@codebutler.com>
+ * Copyright 2018-2019 Michael Farrell <micolous+git@gmail.com>
+ * Copyright 2018-2019 Google
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,6 +22,7 @@ package au.id.micolous.metrodroid.card.felica
 
 import au.id.micolous.metrodroid.multi.Localizer
 import au.id.micolous.metrodroid.multi.R
+import au.id.micolous.metrodroid.serializers.XMLId
 import au.id.micolous.metrodroid.serializers.XMLListIdx
 import au.id.micolous.metrodroid.ui.ListItem
 import au.id.micolous.metrodroid.ui.ListItemRecursive
@@ -27,12 +30,32 @@ import au.id.micolous.metrodroid.util.hexString
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class FelicaSystem(@XMLListIdx("code")
-                        val services: Map<Int, FelicaService>) {
+data class FelicaSystem(
+    /** Service codes that are present in this System */
+    @XMLListIdx("code") val services: Map<Int, FelicaService> = emptyMap(),
+    /** When reading, did we skip trying to read the contents of this system? */
+    @XMLId("skipped") val skipped: Boolean = false) {
     fun getService(serviceCode: Int) = services[serviceCode]
 
-    fun rawData(systemCode: Int): List<ListItem> =
-            services.map { (serviceCode, service) ->
+    /** Shows raw data for all Services within this System */
+    fun rawData(systemCode: Int): List<ListItem> {
+        val emptyServices = services.filterValues { it.blocks.isEmpty() }
+        val skippedServiceIds = emptyServices.filterValues { it.skipped }.keys
+        val emptyServiceIds = emptyServices.filterValues { !it.skipped }.keys
+
+        return listOfNotNull(
+            if (emptyServiceIds.isEmpty()) { null } else {
+                ListItem("${emptyServiceIds.size} empty service codes",
+                    emptyServiceIds.joinToString { it.hexString })
+            },
+            if (skippedServiceIds.isEmpty()) { null } else {
+                ListItem("${skippedServiceIds.size} skipped service codes",
+                    skippedServiceIds.joinToString { it.hexString })
+            }
+        ) + services.mapNotNull { (serviceCode, service) ->
+            if (service.blocks.isEmpty()) {
+                null
+            } else {
                 ListItemRecursive(
                         Localizer.localizeString(R.string.felica_service_title_format,
                                 serviceCode.hexString,
@@ -42,4 +65,6 @@ data class FelicaSystem(@XMLListIdx("code")
                         Localizer.localizePlural(R.plurals.block_count,
                                 service.blocks.size, service.blocks.size), service.rawData)
             }
+        }
+    }
 }

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/felica/FelicaSystem.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/felica/FelicaSystem.kt
@@ -45,11 +45,13 @@ data class FelicaSystem(
 
         return listOfNotNull(
             if (emptyServiceIds.isEmpty()) { null } else {
-                ListItem("${emptyServiceIds.size} empty service codes",
+                ListItem(Localizer.localizePlural(R.plurals.felica_empty_service_codes,
+                    emptyServiceIds.size, emptyServiceIds.size),
                     emptyServiceIds.joinToString { it.hexString })
             },
             if (skippedServiceIds.isEmpty()) { null } else {
-                ListItem("${skippedServiceIds.size} skipped service codes",
+                ListItem(Localizer.localizePlural(R.plurals.felica_skipped_service_codes,
+                    skippedServiceIds.size, skippedServiceIds.size),
                     skippedServiceIds.joinToString { it.hexString })
             }
         ) + services.mapNotNull { (serviceCode, service) ->

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/CardInfo.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/CardInfo.kt
@@ -47,7 +47,9 @@ class CardInfo(
         val imageId: DrawableResource? = null,
         val imageAlphaId: DrawableResource? = null,
 
-        val iOSSupported: Boolean? = null) {
+        val iOSSupported: Boolean? = null,
+        /** Replaces [resourceExtraNote] on iOS only. */
+        val iOSExtraNote: StringResource? = null) {
 
     // TODO: Make this the primary constructor
     constructor(
@@ -61,7 +63,8 @@ class CardInfo(
             resourceExtraNote: StringResource? = null,
             imageId: DrawableResource? = null,
             imageAlphaId: DrawableResource? = null,
-            iOSSupported: Boolean? = null
+            iOSSupported: Boolean? = null,
+            iOSExtraNote: StringResource? = null
     ) : this(
             name = Localizer.localizeString(name),
             cardType = cardType,
@@ -73,6 +76,7 @@ class CardInfo(
             imageId = imageId,
             imageAlphaId = imageAlphaId,
             iOSSupported = iOSSupported,
+            iOSExtraNote = iOSExtraNote,
             region = region)
 
     val hasBitmap get() = imageId != null

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/octopus/OctopusTransitData.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/octopus/OctopusTransitData.kt
@@ -92,6 +92,7 @@ class OctopusTransitData private constructor(private val mOctopusBalance: Int?,
                 name = R.string.card_name_octopus,
                 locationId = R.string.location_hong_kong,
                 region = TransitRegion.HONG_KONG,
+                iOSExtraNote = R.string.card_note_octopus_ios,
                 cardType = CardType.FeliCa)
 
         val FACTORY: FelicaCardTransitFactory = object : FelicaCardTransitFactory {

--- a/src/commonTest/assets/felica/felica-empty-system.json
+++ b/src/commonTest/assets/felica/felica-empty-system.json
@@ -1,0 +1,24 @@
+{
+  "tagId": "0101010101010101",
+  "scannedAt": {
+    "timeInMillis": 1500000000000,
+    "tz": "Australia/Sydney"
+  },
+  "felica": {
+    "pMm": "053143454682b7ff",
+    "systems": {
+      3: {
+        "services": {
+          1: {
+            "blocks": [
+              {"data": "00000000000000000000000000000000"}
+            ]
+          }
+        }
+      },
+      4: {
+        "services": {}
+      }
+    }
+  }
+}

--- a/src/commonTest/assets/felica/felica-skipped-service.json
+++ b/src/commonTest/assets/felica/felica-skipped-service.json
@@ -1,0 +1,27 @@
+{
+  "tagId": "0101010101010101",
+  "scannedAt": {
+    "timeInMillis": 1500000000000,
+    "tz": "Australia/Sydney"
+  },
+  "felica": {
+    "pMm": "053143454682b7ff",
+    "systems": {
+      3: {
+        "services": {
+          0: { "skipped": true },
+          1: {
+            "blocks": [
+              {"data": "00000000000000000000000000000000"}
+            ]
+          },
+          2: {
+            "skipped": true,
+            "blocks": []
+          },
+          3: { "blocks": [] }
+        }
+      }
+    }
+  }
+}

--- a/src/commonTest/assets/felica/felica-skipped-system-missing-services.json
+++ b/src/commonTest/assets/felica/felica-skipped-system-missing-services.json
@@ -1,0 +1,24 @@
+{
+  "tagId": "0101010101010101",
+  "scannedAt": {
+    "timeInMillis": 1500000000000,
+    "tz": "Australia/Sydney"
+  },
+  "felica": {
+    "pMm": "053143454682b7ff",
+    "systems": {
+      3: {
+        "services": {
+          1: {
+            "blocks": [
+              {"data": "00000000000000000000000000000000"}
+            ]
+          }
+        }
+      },
+      4: {
+        "skipped": true
+      }
+    }
+  }
+}

--- a/src/commonTest/assets/felica/felica-skipped-system.json
+++ b/src/commonTest/assets/felica/felica-skipped-system.json
@@ -1,0 +1,25 @@
+{
+  "tagId": "0101010101010101",
+  "scannedAt": {
+    "timeInMillis": 1500000000000,
+    "tz": "Australia/Sydney"
+  },
+  "felica": {
+    "pMm": "053143454682b7ff",
+    "systems": {
+      3: {
+        "services": {
+          1: {
+            "blocks": [
+              {"data": "00000000000000000000000000000000"}
+            ]
+          }
+        }
+      },
+      4: {
+        "services": {},
+        "skipped": true
+      }
+    }
+  }
+}

--- a/src/commonTest/kotlin/au/id/micolous/metrodroid/test/FelicaJsonImportTest.kt
+++ b/src/commonTest/kotlin/au/id/micolous/metrodroid/test/FelicaJsonImportTest.kt
@@ -21,32 +21,116 @@ package au.id.micolous.metrodroid.test
 import au.id.micolous.metrodroid.card.felica.FelicaCard
 import au.id.micolous.metrodroid.serializers.JsonKotlinFormat
 import au.id.micolous.metrodroid.util.ImmutableByteArray
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
+import kotlin.test.*
 
 class FelicaJsonImportTest: CardReaderWithAssetDumpsTest(JsonKotlinFormat)  {
+
+    private fun checkLoadCard(path: String): FelicaCard {
+        val c = loadCard<FelicaCard>(path)
+        assertEquals(ImmutableByteArray.fromHex("0101010101010101"), c.tagId)
+        val felica = c.felica
+        assertNotNull(felica)
+        checkDummySystem3(felica)
+        return felica
+    }
+
+    /**
+     * Checks for the presence of a system 3 on the card, with the dummy contents: a single
+     * service, 0x1, with 1 block containing 16 bytes of null.
+     */
+    private fun checkDummySystem3(felica: FelicaCard) {
+        val system = felica.systems[3]
+        assertNotNull(system)
+        val service = system.services[1]
+        assertNotNull(service)
+        assertFalse(service.skipped)
+        val blocks = service.blocks.toList()
+        assertEquals(1, blocks.count())
+        val data = blocks[0].data
+        assertEquals(ImmutableByteArray.empty(16), data)
+    }
+
+    private fun checkSkippedSystem4(felica: FelicaCard) {
+        val system = felica.systems[4]
+        assertNotNull(system)
+        assertTrue(system.skipped)
+        assertTrue(system.services.isEmpty())
+    }
+
     /**
      * Test reading a FeliCa JSON dump with IDm tag (like <= v2.9.37)
      */
     @Test
-    fun testFelicaJsonIdm() {
-        val c = loadCard<FelicaCard>("felica/felica-idm.json")
-        assertEquals(ImmutableByteArray.fromHex("0101010101010101"), c.tagId)
-        val felica = c.felica
-        assertNotNull(felica)
-        assertEquals(setOf(3), felica.systems.keys)
+    fun testIdm() {
+        checkLoadCard("felica/felica-idm.json")
     }
 
     /**
      * Test reading a FeliCa JSON dump without IDm tag (like >= v2.9.38)
      */
     @Test
-    fun testFelicaJsonNoIdm() {
-        val c = loadCard<FelicaCard>("felica/felica-no-idm.json")
-        assertEquals(ImmutableByteArray.fromHex("0101010101010101"), c.tagId)
-        val felica = c.felica
-        assertNotNull(felica)
-        assertEquals(setOf(3), felica.systems.keys)
+    fun testNoIdm() {
+        checkLoadCard("felica/felica-no-idm.json")
     }
+
+    /**
+     * Test reading a FeliCa JSON dump which has a system code 4 which has an empty services map
+     * and not marked as "skipped".
+     */
+    @Test
+    fun testEmptySystem() {
+        val felica = checkLoadCard("felica/felica-empty-system.json")
+        val system = felica.systems[4]
+        assertNotNull(system)
+        assertFalse(system.skipped)
+        assertTrue(system.services.isEmpty())
+    }
+
+    /**
+     * Test reading a FeliCa JSON dump which has a system code 4 which has an empty services map
+     * and marked as "skipped".
+     */
+    @Test
+    fun testSkippedSystem() {
+        val felica = checkLoadCard("felica/felica-skipped-system.json")
+        checkSkippedSystem4(felica)
+    }
+
+    /**
+     * Test reading a FeliCa JSON dump which has a system code 4 which has no services map and is
+     * marked as "skipped".
+     */
+    @Test
+    fun testSkippedSystemMissingServices() {
+        val felica = checkLoadCard("felica/felica-skipped-system-missing-services.json")
+        checkSkippedSystem4(felica)
+    }
+
+    /**
+     * Test reading a FeliCa JSON dump which has a system code 3 with extra services:
+     *
+     * * 0: `"skipped": true`
+     * * 1: same as `felica-idm.json`
+     * * 2: `"skipped": true, "blocks": {}`
+     * * 3: `"blocks": []`
+     *
+     * Per FeliCa spec, even-numbered service codes require authentication to access.
+     */
+    @Test
+    fun testSkippedService() {
+        val felica = checkLoadCard("felica/felica-skipped-service.json")
+        val system = felica.systems[3]
+        assertNotNull(system)
+        for (f in listOf(0, 2, 3)) {
+            val service = system.services[f]
+            assertNotNull(service, "service $f must be present")
+            if (f % 2 == 0) {
+                assertTrue(service.skipped, "service $f must be marked as skipped")
+            } else {
+                assertFalse(service.skipped, "service $f must not be skipped")
+            }
+            assertTrue(service.blocks.isEmpty(), "service $f must have an empty list of blocks")
+        }
+    }
+
 }

--- a/src/iOSMain/kotlin/au/id/micolous/metrodroid/card/felica/FelicaCardReaderIOS.kt
+++ b/src/iOSMain/kotlin/au/id/micolous/metrodroid/card/felica/FelicaCardReaderIOS.kt
@@ -38,7 +38,20 @@ object FelicaCardReaderIOS {
         Log.d(TAG, "Start dump ${xfer.uid}")
         runBlocking {
             Log.d(TAG, "Start async")
-            val df = FelicaReader.dumpTag(xfer, feedback)
+
+            /*
+             * onlyFirst = true is an iOS-specific hack to work around
+             * https://github.com/metrodroid/metrodroid/issues/613
+             *
+             * _NFReaderSession._validateFelicaCommand asserts that you're talking to the exact
+             * IDm that the system discovered -- including the upper 4 bits (which indicate the
+             * system number).
+             *
+             * Tell FelicaReader to only dump the first service.
+             *
+             * Once iOS fixes this, do an iOS version check instead.
+             */
+            val df = FelicaReader.dumpTag(xfer, feedback, onlyFirst = true)
             Card(tagId = xfer.uid?.let { if (it.size == 10) it.sliceOffLen(0, 7) else it }!!,
             scannedAt = TimestampFull.now(), felica = df)
         }

--- a/src/jvmCommonTest/kotlin/au/id/micolous/metrodroid/test/FelicaXmlImportTest.kt
+++ b/src/jvmCommonTest/kotlin/au/id/micolous/metrodroid/test/FelicaXmlImportTest.kt
@@ -23,19 +23,41 @@ import au.id.micolous.metrodroid.serializers.XmlCardFormat
 import au.id.micolous.metrodroid.util.ImmutableByteArray
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 
 class FelicaXmlImportTest: CardReaderWithAssetDumpsTest(XmlCardFormat())  {
+    private fun checkLoadCard(path: String): FelicaCard {
+        val c = loadCard<FelicaCard>(path)
+        assertEquals(ImmutableByteArray.fromHex("0101010101010101"), c.tagId)
+        val felica = c.felica
+        assertNotNull(felica)
+        checkDummySystem3(felica)
+        return felica
+    }
+
+    /**
+     * Checks for the presence of a system 3 on the card, with the dummy contents: a single
+     * service, 0x1, with 1 block containing 16 bytes of null.
+     */
+    private fun checkDummySystem3(felica: FelicaCard) {
+        val system = felica.systems[3]
+        assertNotNull(system)
+        val service = system.services[1]
+        assertNotNull(service)
+        assertFalse(service.skipped)
+        val blocks = service.blocks.toList()
+        assertEquals(1, blocks.count())
+        val data = blocks[0].data
+        assertEquals(ImmutableByteArray.empty(16), data)
+    }
+
     /**
      * Test reading a FeliCa XML dump with IDm tag (like <= v2.9.37)
      */
     @Test
     fun testFelicaXmlIdm() {
-        val c = loadCard<FelicaCard>("felica/felica-idm.xml")
-        assertEquals(ImmutableByteArray.fromHex("0101010101010101"), c.tagId)
-        val felica = c.felica
-        assertNotNull(felica)
-        assertEquals(setOf(3), felica.systems.keys)
+        checkLoadCard("felica/felica-idm.xml")
     }
 
     /**
@@ -43,10 +65,6 @@ class FelicaXmlImportTest: CardReaderWithAssetDumpsTest(XmlCardFormat())  {
      */
     @Test
     fun testFelicaXmlNoIdm() {
-        val c = loadCard<FelicaCard>("felica/felica-no-idm.xml")
-        assertEquals(ImmutableByteArray.fromHex("0101010101010101"), c.tagId)
-        val felica = c.felica
-        assertNotNull(felica)
-        assertEquals(setOf(3), felica.systems.keys)
+        checkLoadCard("felica/felica-no-idm.xml")
     }
 }

--- a/src/main/java/au/id/micolous/metrodroid/activity/MainActivity.kt
+++ b/src/main/java/au/id/micolous/metrodroid/activity/MainActivity.kt
@@ -1,10 +1,9 @@
 /*
  * MainActivity.kt
  *
- * Copyright (C) 2011 Eric Butler
- *
- * Authors:
- * Eric Butler <eric@codebutler.com>
+ * Copyright 2011-2015 Eric Butler <eric@codebutler.com>
+ * Copyright 2015-2019 Michael Farrell <micolous+git@gmail.com>
+ * Copyright 2018-2019 Google
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -42,6 +41,7 @@ import au.id.micolous.metrodroid.util.Preferences
 import au.id.micolous.metrodroid.util.Utils
 
 import au.id.micolous.farebot.R
+import au.id.micolous.metrodroid.util.ifTrue
 
 class MainActivity : MetrodroidActivity() {
     private var mNfcAdapter: NfcAdapter? = null
@@ -97,10 +97,15 @@ class MainActivity : MetrodroidActivity() {
                 if (Preferences.obfuscateTripTimes) 1 else 0
 
         val directions = findViewById<TextView>(R.id.directions)
+        val felicaNote = Preferences.felicaOnlyFirst.ifTrue { R.string.felica_first_system_notice }
 
         if (obfuscationFlagsOn > 0) {
-            directions.text = Localizer.localizePlural(R.plurals.obfuscation_mode_notice,
-                    obfuscationFlagsOn, obfuscationFlagsOn)
+            val flagsNote = Localizer.localizePlural(
+                R.plurals.obfuscation_mode_notice, obfuscationFlagsOn, obfuscationFlagsOn)
+            directions.text = felicaNote?.let {
+                "${Localizer.localizeString(it)} $flagsNote" } ?: flagsNote
+        } else if (felicaNote != null) {
+            directions.setText(felicaNote)
         } else if (!hasNfc) {
             directions.setText(R.string.nfc_unavailable)
         } else {

--- a/src/main/java/au/id/micolous/metrodroid/card/CardReader.kt
+++ b/src/main/java/au/id/micolous/metrodroid/card/CardReader.kt
@@ -16,6 +16,7 @@ import au.id.micolous.metrodroid.card.ultralight.UltralightCardReader
 import au.id.micolous.metrodroid.card.ultralight.UltralightCardReaderA
 import au.id.micolous.metrodroid.multi.Localizer
 import au.id.micolous.metrodroid.time.TimestampFull
+import au.id.micolous.metrodroid.util.Preferences
 import au.id.micolous.metrodroid.util.toImmutable
 
 
@@ -64,7 +65,8 @@ object CardReader {
             val transceiver = AndroidFelicaTransceiver(tag)
 
             transceiver.connect()
-            val c = FelicaReader.dumpTag(transceiver, feedbackInterface)
+            val c = FelicaReader.dumpTag(
+                transceiver, feedbackInterface, onlyFirst = Preferences.felicaOnlyFirst)
             transceiver.close()
             return Card(tagId = tagId, scannedAt = TimestampFull.now(), felica = c)
 

--- a/src/main/java/au/id/micolous/metrodroid/util/Preferences.kt
+++ b/src/main/java/au/id/micolous/metrodroid/util/Preferences.kt
@@ -38,6 +38,7 @@ actual object Preferences {
     const val PREF_LAST_READ_AT = "last_read_at"
     private const val PREF_MFC_AUTHRETRY = "pref_mfc_authretry"
     private const val PREF_MFC_FALLBACK = "pref_mfc_fallback"
+    private const val PREF_FELICA_ONLY_FIRST = "pref_felica_only_first"
     private const val PREF_RETRIEVE_LEAP_KEYS = "pref_retrieve_leap_keys"
 
     private const val PREF_HIDE_CARD_NUMBERS = "pref_hide_card_numbers"
@@ -176,6 +177,8 @@ actual object Preferences {
             TransitData.RawLevel.NONE.toString())) ?: TransitData.RawLevel.NONE
 
     val overrideLang get() = getStringPreference(PREF_LANG_OVERRIDE, "")
+
+    val felicaOnlyFirst get() = getBooleanPref(PREF_FELICA_ONLY_FIRST, false)
 
     actual val metrodroidVersion: String
         get() = BuildConfig.VERSION_NAME

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1363,7 +1363,13 @@
     <string name="card_name_szt">Shenzhen Tong</string>
     <!-- Translators: Transit card in Hong Kong. Chinese: 八達通. -->
     <string name="card_name_octopus">Octopus</string>
+    <!-- Translators: Transit card in Hong Kong and Shenzhen. Chinese: 互通行 -->
     <string name="card_name_octopus_szt_dual">Hu Tong Xing</string>
+    <!--
+    Translators: Hu Tong Xing (Chinese: 互通行) is a transit card used in Hong Kong and Shenzhen.
+    This note is only displayed on iOS: https://github.com/metrodroid/metrodroid/issues/613
+    -->
+    <string name="card_note_octopus_ios">Hu Tong Xing not supported.</string>
     <string name="szt_metro">Shenzhen Metro</string>
     <string name="szt_bus">Shenzhen Bus</string>
     <string name="szt_station_gate">gate %s</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1986,6 +1986,8 @@
     <string name="trip_counter">Trips counter</string>
     <string name="refill_counter">Refill counter</string>
     <string name="mifare_desfire">MIFARE DESFire</string>
+    <!-- Translators: type of card media (フェリカ / Felicity Card) -->
+    <string name="card_media_felica">FeliCa</string>
     <!-- Translators: type of card media, variant of FeliCa (フェリカ / Felicity Card) -->
     <string name="card_media_felica_lite">FeliCa Lite</string>
     <string name="felica_lite_read_only">Read-only data</string>
@@ -1995,6 +1997,28 @@
     <!-- Translators: area of card storage shared by Suica and Edy,
          possibly othewr systems as well. -->
     <string name="felica_system_common">Common Area (FeliCa Networks)</string>
+    <!--
+    Translators:
+    Used as a preference title. FeliCa divides cards into "systems" (~applications) and "services"
+    (~files). A single card may have more than one "system".
+
+    By default, this preference is disabled: Metrodroid reads all systems from a FeliCa card.
+
+    When this preference is enabled, Metrodroid will only read the first system on a FeliCa card.
+    -->
+    <string name="felica_first_system_pref">Only read first system</string>
+    <!--
+    Translators:
+    See 'felica_first_system_pref' for explanation of the preference.
+    This is used as a summary when the preference is disabled (default).
+    -->
+    <string name="felica_first_system_pref_summary_off">Metrodroid will read all systems on FeliCa cards. This is the default.</string>
+    <!--
+    Translators:
+    See 'felica_first_system_pref' for explanation of the preference.
+    This is used as a summary when the preference is enabled.
+    -->
+    <string name="felica_first_system_pref_summary_on">Metrodroid will read only the first system on FeliCa cards. This simulates a workaround for a bug in iOS. Reads of multi-system FeliCa cards will be incomplete!</string>
 
     <!-- TFI Leap -->
     <string name="leap_retrieve_keys">Retrieve keys for Leap cards</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -2020,6 +2020,52 @@
     -->
     <string name="felica_first_system_pref_summary_on">Metrodroid will read only the first system on FeliCa cards. This simulates a workaround for a bug in iOS. Reads of multi-system FeliCa cards will be incomplete!</string>
 
+    <!--
+    Translators:
+    Used as a description for a FeliCa system code (~application) which does
+    not contain any services (~files).
+    -->
+    <string name="felica_empty_system">Empty system</string>
+
+    <!--
+    Translators:
+    Used as a description for a FeliCa system code (~application) which was not
+    read. This is because of a work-around for an iOS bug.
+    -->
+    <string name="felica_skipped_system">Skipped reading system</string>
+
+    <!--
+    Translators:
+    Used as a title for a list of FeliCa service codes (~file numbers)
+    that either contain 0 blocks, or all blocks contain null bytes.
+    -->
+    <plurals name="felica_empty_service_codes">
+        <item quantity="one">%d empty service code</item>
+        <item quantity="other">%d empty service codes</item>
+    </plurals>
+
+    <!--
+    Translators:
+    Used as a title for a list of FeliCa service codes (~file numbers)
+    that were never read from the original card. This can be because the
+    service codes were locked, or because of a software bug.
+    -->
+    <plurals name="felica_skipped_service_codes">
+        <item quantity="one">%d skipped service code</item>
+        <item quantity="other">%d skipped service codes</item>
+    </plurals>
+
+    <!--
+    Translators:
+    This notice is shown on the main screen whenever "felica_first_system_pref" is enabled on
+    Android. Enabling that setting may lead to an incomplete data read, and we don't want it left
+    on accidentally.
+
+    This is shown on the main window, instead of the "directions" string; and may be
+    in addition to the "obfuscation_mode_notice".
+    -->
+    <string name="felica_first_system_notice">FeliCa reads will be incomplete.</string>
+
     <!-- TFI Leap -->
     <string name="leap_retrieve_keys">Retrieve keys for Leap cards</string>
     <string name="leap_retrieve_keys_longdesc">Shares your card details with Transport for Ireland, in order to respond to the Leap card\'s authentication challenge. TFI will know you used Metrodroid on this card. The card can not be read without this key.</string>

--- a/src/main/res/xml/prefs.xml
+++ b/src/main/res/xml/prefs.xml
@@ -202,6 +202,15 @@
                 android:key="pref_obfuscate_trip_fares"
                 android:defaultValue="false" />
         </PreferenceCategory>
+
+        <PreferenceCategory android:title="@string/card_media_felica">
+            <CheckBoxPreference
+                android:title="@string/felica_first_system_pref"
+                android:summaryOff="@string/felica_first_system_pref_summary_off"
+                android:summaryOn="@string/felica_first_system_pref_summary_on"
+                android:key="pref_felica_only_first"
+                android:defaultValue="false" />
+        </PreferenceCategory>
     </PreferenceScreen>
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
This is on top of #672; as iOS version doesn't build without that patch.

This adds a new parameter to `FelicaReader.dumpTag`, `onlyFirst`.  When `onlyFirst = true`, any system codes after `index 0` will be skipped, an empty `FelicaService` is inserted in place, and the event is logged.

* On Android, there is a new developer option to toggle this setting. I didn't put it in "NFC Preferences" because this should only be used for debugging and development.
* On iOS, `onlyFirst` is hard coded to `true` to work around #613.

This will probably only read the Octopus part of Hu Tong Xing (互通行).  I don't have a sample to test with this for sure, but I think this will only fully work once the underlying bug in iOS is fixed.

I tested this with these single-system cards (which work already, and also work after this patch)

* ICOCA
* nimoca

I tested tested with these multi-system cards (which don't work without this patch):

* Hayakaken
* PASMO
* Suica

This will also impact these other cards, but I don't have samples to test with:

* KMT (single-system)
* Octopus (single-system)
* Shenzhen Tong 1G (probably single-system)

I tested this build on iPhone 7 with iOS 13.0.  There's now 13.1.2 out publicly which I should also try with; but I don't think this will change much as Apple has not responded to any communications.