### PR TITLE
ios: Require nfc hardware

### DIFF
--- a/native/metrodroid/metrodroid/Info.plist
+++ b/native/metrodroid/metrodroid/Info.plist
@@ -34,6 +34,7 @@
 	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
+		<string>nfc</string>
 		<string>armv7</string>
 	</array>
 	<key>UISupportedInterfaceOrientations</key>

--- a/src/iOSMain/kotlin/au/id/micolous/metrodroid/time/Timestamp.kt
+++ b/src/iOSMain/kotlin/au/id/micolous/metrodroid/time/Timestamp.kt
@@ -61,7 +61,7 @@ internal actual fun epochDayHourMinToMillis(tz: MetroTimeZone, daysSinceEpoch: I
     val ymd = getYMD(daysSinceEpoch)
     val nstz = metroTz2NS(tz)
     dateComponents.day = ymd.day.toLong()
-    dateComponents.month = ymd.month.toLong() + 1
+    dateComponents.month = ymd.month.oneBasedIndex.toLong()
     dateComponents.year = ymd.year.toLong()
     dateComponents.hour = hour.toLong()
     dateComponents.minute = min.toLong()


### PR DESCRIPTION
This is built on #672, because the build is broken without it.

This prevents Metrodroid being offered on hardware that doesn't support CoreNFC (eg: iPhone 6; iPad).

Device/Capabilities matrix here: https://developer.apple.com/support/required-device-capabilities/