### PR TITLE
WIP: localize card_media strings

### DIFF
--- a/docs/ios.md
+++ b/docs/ios.md
@@ -60,9 +60,22 @@ Metrodroid for iOS **does not support**:
 
 * **EMV cards**: the EMV protocol requires dynamic AID selection, which is not allowed on iOS.
 
-* **FeliCa cards with more than one system not supported**: [this appears to be an iOS
-  bug][ios-felica]. This impacts Hu Tong Xing (互通行) cards, as well as some Hayakaken, PASMO and
-  Suica cards. ICOCA and nimoca cards both appear fine.
+* **FeliCa cards that use system codes other than the first**: [due to a bug in iOS][ios-felica],
+  Metrodroid on iOS can only read the _first_ system code on a card. Metrodroid on iOS will
+  instead leave empty placeholder system(s) for other system codes -- whereas Metrodroid on Android
+  will try to read the contents of other system codes.
+
+  * **Single-system FeliCa cards** (such as KMT, ICOCA, nimoca and Octopus) are _not_ impacted.
+
+  * **Multi-system [Japan IC][] cards** (such as Hayakaken, PASMO and Suica) will only read system
+    code `0x3`. This is where the payment and ticketing data is stored, so _most users will not see
+    any difference_.
+
+    The FeliCa Networks Common Area (`0xfe00`), and other miscellaneous system codes will not be
+    read; but these cannot be parsed by Metrodroid anyway.
+
+  * **Hu Tong Xing (互通行)** (untested) will probably _only_ read the Octopus (HKD) purse balance,
+    and not the Shenzhen Tong (CNY) purse balance.
 
 * **Leap**: unlocking Leap cards is not implemented.
 
@@ -199,6 +212,7 @@ changes have been removed from `native/metrodroid/metrodroid.xcodeproj/project.p
 [dev-caps]: https://help.apple.com/developer-account/#/dev21218dfd6
 [ios-felica]: https://github.com/metrodroid/metrodroid/issues/613
 [ios-issue]: https://github.com/metrodroid/metrodroid/issues/new?assignees=&labels=bug&template=bug.md&title=%5BBUG%5D
+[Japan IC]: https://github.com/metrodroid/metrodroid/wiki/IC-%28Japan%29
 [signing-workflow]: https://help.apple.com/xcode/mac/current/#/dev60b6fbbc7
 [TestFlight]: https://developer.apple.com/testflight/
 [xcode-setup]: https://help.apple.com/xcode/mac/current/#/devaf282080a

--- a/native/metrodroid/metrodroid/AdvancedCardViewController.swift
+++ b/native/metrodroid/metrodroid/AdvancedCardViewController.swift
@@ -71,12 +71,8 @@ class AdvancedCardViewController: UITabBarController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        var hiddenSerial: String? = nil
-        if (Preferences.init().hideCardNumbers) {
-            hiddenSerial = Utils.localizeString(RKt.R.string.hidden_card_number)
-        }
-        let unknown = Utils.localizeString(RKt.R.string.unknown)
-        title = "\(card?.cardType.name ?? unknown) - \(hiddenSerial ?? card?.tagId.toHexString() ?? unknown)"
+        title = Utils.cardMediaDescription(card)
+
         self.viewControllers = self.viewControllers?.filter { v in
             ((v as? CardViewProtocol)?.setTransitData(card: card!, transitData: nil) ?? false)
         }

--- a/native/metrodroid/metrodroid/CardViewController.swift
+++ b/native/metrodroid/metrodroid/CardViewController.swift
@@ -106,12 +106,7 @@ class CardViewController: UITabBarController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        var hiddenSerial: String? = nil
-        if (Preferences.init().hideCardNumbers) {
-            hiddenSerial = Utils.localizeString(RKt.R.string.hidden_card_number)
-        }
-        let unknown = Utils.localizeString(RKt.R.string.unknown)
-        title = "\(td?.cardName ?? unknown) \(Utils.directedDash) \(hiddenSerial ?? (td?.serialNumber ?? card?.tagId.toHexString()).flatMap(Utils.weakLTR) ?? unknown)"
+        title = Utils.cardMediaDescription(card)
         self.viewControllers = self.viewControllers?.filter { v in
             ((v as? CardViewProtocol)?.setTransitData(card: card!, transitData: td) ?? false)
         }

--- a/native/metrodroid/metrodroid/Utils.swift
+++ b/native/metrodroid/metrodroid/Utils.swift
@@ -197,4 +197,17 @@ class Utils {
             return "-"
         }
     }
+    
+    /**
+     Returns a localized string describing a card's media and serial number.
+
+     - Parameter card: The card to describe. If `nil`, then a localized "Unknown card" string is returned.
+     - Returns: Localized string. If `Preferences.hideCardNumbers == true`, the serial number is omitted from the output.
+     */
+    class func cardMediaDescription(_ card: Card?) -> String {
+        let cardType = Utils.localizeString(card?.cardType.label ?? CardType.unknown.label)
+        let cardSerial = Preferences.init().hideCardNumbers ? nil : card?.tagId.getHexString()
+        return (cardSerial == nil ? cardType :
+            Utils.localizeString(RKt.R.string.card_media_placeholder, cardType, card))
+    }
 }

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/CardType.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/CardType.kt
@@ -2,7 +2,7 @@
  * CardType.kt
  *
  * Copyright 2011-2014 Eric Butler <eric@codebutler.com>
- * Copyright 2015, 2018 Michael Farrell <micolous+git@gmail.com>
+ * Copyright 2015-2019 Michael Farrell <micolous+git@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,36 +19,25 @@
  */
 package au.id.micolous.metrodroid.card
 
-enum class CardType constructor(private val mValue: Int) {
-    MifareClassic(0),
-    MifareUltralight(1),
-    MifareDesfire(2),
-    CEPAS(3),
-    FeliCa(4),
-    ISO7816(5),
-    MultiProtocol(7),
-    Vicinity(8),
-    MifarePlus(9),
-    Unknown(65535);
+import au.id.micolous.metrodroid.multi.R
+import au.id.micolous.metrodroid.multi.StringResource
 
-    fun toInteger() = mValue
+enum class CardType(
+    val value: Int,
+    val label: StringResource) {
 
-    override fun toString() = when (mValue) {
-        0 -> "MIFARE Classic"
-        1 -> "MIFARE Ultralight"
-        2 -> "MIFARE DESFire"
-        3 -> "CEPAS"
-        4 -> "FeliCa"
-        5 -> "ISO7816"
-        6 -> "Calypso"
-        7 -> "Multi-protocol"
-        8 -> "Vicinity"
-        9 -> "MIFARE Plus"
-        65535 -> "Unknown"
-        else -> "Unknown"
-    }
+    MifareClassic(0, R.string.card_media_mfc),
+    MifareUltralight(1, R.string.card_media_mfu),
+    MifareDesfire(2, R.string.card_media_mfd),
+    CEPAS(3, R.string.card_media_cepas),
+    FeliCa(4, R.string.card_media_felica),
+    ISO7816(5, R.string.card_media_iso7816),
+    MultiProtocol(7, R.string.card_media_multi_protocol),
+    Vicinity(8, R.string.card_media_vicinity),
+    MifarePlus(9, R.string.card_media_mfp),
+    Unknown(65535, R.string.unknown_card);
 
     companion object {
-        fun parseValue(value: Int): CardType? = values().find { it.mValue == value }
+        fun parseValue(value: Int) = values().find { it.value == value } ?: Unknown
     }
 }

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/serializers/XmlCardFormat.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/serializers/XmlCardFormat.kt
@@ -539,7 +539,7 @@ fun readCardXML(root: NodeWrapper): Card = logAndSwiftWrap("XmlCardFormat", "XML
     if (root.nodeName != "card")
         throw Exception("Invalid root ${root.nodeName}")
     val cardType = root.attributes["type"] ?: throw Exception("type attribute not found")
-    val xi = XMLInput(root, strict = cardType.toInt() != CardType.CEPAS.toInteger(),
+    val xi = XMLInput(root, strict = cardType.toInt() != CardType.CEPAS.value,
             ignore = setOf("type", "id", "scanned_at", "label"),
             skippable = setOf("ultralightType", "idm"))
     val tagId = ImmutableByteArray.fromHex(root.attributes.getValue("id"))
@@ -547,22 +547,22 @@ fun readCardXML(root: NodeWrapper): Card = logAndSwiftWrap("XmlCardFormat", "XML
             tz = MetroTimeZone.LOCAL)
     val label = root.attributes["label"]
     when (cardType.toInt()) {
-        CardType.MifareClassic.toInteger() -> Card(
+        CardType.MifareClassic.value -> Card(
                 tagId = tagId, scannedAt = scannedAt, label = label,
                 mifareClassic = xi.decode(ClassicCard.serializer()))
-        CardType.MifareUltralight.toInteger() -> Card(
+        CardType.MifareUltralight.value -> Card(
                 tagId = tagId, scannedAt = scannedAt, label = label,
                 mifareUltralight = xi.decode(UltralightCard.serializer()))
-        CardType.MifareDesfire.toInteger() -> Card(
+        CardType.MifareDesfire.value -> Card(
                 tagId = tagId, scannedAt = scannedAt, label = label,
                 mifareDesfire = xi.decode(DesfireCard.serializer()))
-        CardType.CEPAS.toInteger() -> Card(
+        CardType.CEPAS.value -> Card(
                 tagId = tagId, scannedAt = scannedAt, label = label,
                 cepasCompat = xi.decode(CEPASCard.serializer()))
-        CardType.FeliCa.toInteger() -> Card(
+        CardType.FeliCa.value -> Card(
                 tagId = tagId, scannedAt = scannedAt, label = label,
                 felica = xi.decode(FelicaCard.serializer()))
-        CardType.ISO7816.toInteger() -> Card(
+        CardType.ISO7816.value -> Card(
                 tagId = tagId, scannedAt = scannedAt, label = label,
                 iso7816 = xi.decode(ISO7816Card.serializer()))
         else -> throw Exception("Unknown card type $cardType")

--- a/src/iOSMain/kotlin/au/id/micolous/metrodroid/card/felica/FelicaCardReaderIOS.kt
+++ b/src/iOSMain/kotlin/au/id/micolous/metrodroid/card/felica/FelicaCardReaderIOS.kt
@@ -38,7 +38,20 @@ object FelicaCardReaderIOS {
         Log.d(TAG, "Start dump ${xfer.uid}")
         runBlocking {
             Log.d(TAG, "Start async")
-            val df = FelicaReader.dumpTag(xfer, feedback)
+
+            /*
+             * onlyFirst = true is an iOS-specific hack to work around
+             * https://github.com/metrodroid/metrodroid/issues/613
+             *
+             * _NFReaderSession._validateFelicaCommand asserts that you're talking to the exact
+             * IDm that the system discovered -- including the upper 4 bits (which indicate the
+             * system number).
+             *
+             * Tell FelicaReader to only dump the first service.
+             *
+             * Once iOS fixes this, do an iOS version check instead.
+             */
+            val df = FelicaReader.dumpTag(xfer, feedback, onlyFirst = true)
             Card(tagId = xfer.uid?.let { if (it.size == 10) it.sliceOffLen(0, 7) else it }!!,
             scannedAt = TimestampFull.now(), felica = df)
         }

--- a/src/iOSMain/kotlin/au/id/micolous/metrodroid/time/Timestamp.kt
+++ b/src/iOSMain/kotlin/au/id/micolous/metrodroid/time/Timestamp.kt
@@ -61,7 +61,7 @@ internal actual fun epochDayHourMinToMillis(tz: MetroTimeZone, daysSinceEpoch: I
     val ymd = getYMD(daysSinceEpoch)
     val nstz = metroTz2NS(tz)
     dateComponents.day = ymd.day.toLong()
-    dateComponents.month = ymd.month.toLong() + 1
+    dateComponents.month = ymd.month.oneBasedIndex.toLong()
     dateComponents.year = ymd.year.toLong()
     dateComponents.hour = hour.toLong()
     dateComponents.minute = min.toLong()

--- a/src/main/java/au/id/micolous/metrodroid/activity/AdvancedCardInfoActivity.kt
+++ b/src/main/java/au/id/micolous/metrodroid/activity/AdvancedCardInfoActivity.kt
@@ -2,7 +2,7 @@
  * AdvancedCardInfoActivity.kt
  *
  * Copyright (C) 2011 Eric Butler
- * Copyright 2015-2018 Michael Farrell <micolous+git@gmail.com>
+ * Copyright 2015-2019 Michael Farrell <micolous+git@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -84,10 +84,12 @@ class AdvancedCardInfoActivity : MetrodroidActivity() {
 
         setDisplayHomeAsUpEnabled(true)
 
-        if (Preferences.hideCardNumbers) {
-            supportActionBar?.title = card.cardType.toString()
+        val tagId = card.tagId
+        if (Preferences.hideCardNumbers || tagId.isEmpty()) {
+            supportActionBar?.setTitle(card.cardType.label)
         } else {
-            supportActionBar?.title = card.cardType.toString() + " " + card.tagId.toHexString()
+            supportActionBar?.title = Localizer.localizeString(
+                R.string.card_media_placeholder, card.cardType.label, tagId.getHexString())
         }
 
         var scannedAt = card.scannedAt

--- a/src/main/java/au/id/micolous/metrodroid/activity/ReadingTagTask.kt
+++ b/src/main/java/au/id/micolous/metrodroid/activity/ReadingTagTask.kt
@@ -1,3 +1,23 @@
+/*
+ * ReadingTagTask.kt
+ *
+ * Copyright 2011 Eric Butler <eric@codebutler.com>
+ * Copyright 2015-2019 Michael Farrell <micolous+git@gmail.com>
+ * Copyright 2019 Google
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package au.id.micolous.metrodroid.activity
 
 import android.app.AlertDialog
@@ -52,7 +72,7 @@ internal class ReadingTagTask private constructor(
         val tagIdString = card.tagId.toHexString()
 
         val values = ContentValues()
-        values.put(CardsTableColumns.TYPE, card.cardType.toInteger())
+        values.put(CardsTableColumns.TYPE, card.cardType.value)
         values.put(CardsTableColumns.TAG_SERIAL, tagIdString)
         values.put(CardsTableColumns.DATA, cardXml)
         values.put(CardsTableColumns.SCANNED_AT, card.scannedAt.timeInMillis)

--- a/src/main/java/au/id/micolous/metrodroid/card/CardReader.kt
+++ b/src/main/java/au/id/micolous/metrodroid/card/CardReader.kt
@@ -16,6 +16,7 @@ import au.id.micolous.metrodroid.card.ultralight.UltralightCardReader
 import au.id.micolous.metrodroid.card.ultralight.UltralightCardReaderA
 import au.id.micolous.metrodroid.multi.Localizer
 import au.id.micolous.metrodroid.time.TimestampFull
+import au.id.micolous.metrodroid.util.Preferences
 import au.id.micolous.metrodroid.util.toImmutable
 
 
@@ -64,7 +65,8 @@ object CardReader {
             val transceiver = AndroidFelicaTransceiver(tag)
 
             transceiver.connect()
-            val c = FelicaReader.dumpTag(transceiver, feedbackInterface)
+            val c = FelicaReader.dumpTag(
+                transceiver, feedbackInterface, onlyFirst = Preferences.felicaOnlyFirst)
             transceiver.close()
             return Card(tagId = tagId, scannedAt = TimestampFull.now(), felica = c)
 

--- a/src/main/java/au/id/micolous/metrodroid/fragment/CardsFragment.kt
+++ b/src/main/java/au/id/micolous/metrodroid/fragment/CardsFragment.kt
@@ -2,7 +2,7 @@
  * CardsFragment.kt
  *
  * Copyright 2012-2014 Eric Butler <eric@codebutler.com>
- * Copyright 2015-2018 Michael Farrell <micolous+git@gmail.com>
+ * Copyright 2015-2019 Michael Farrell <micolous+git@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -579,10 +579,13 @@ class CardsFragment : ExpandableListFragment(), SearchView.OnQueryTextListener {
                 }
             } else {
                 textView1.setText(R.string.unknown_card)
-                if (Preferences.hideCardNumbers) {
-                    textView2.text = CardType.parseValue(type).toString()
+                val cardType = CardType.parseValue(type)
+                if (Preferences.hideCardNumbers || serial.isEmpty()) {
+                    textView2.setText(cardType.label)
                 } else {
-                    textView2.text = "${CardType.parseValue(type)} - $serial"
+                    textView2.text = Localizer.localizeString(
+                        R.string.card_media_placeholder,
+                        Localizer.localizeString(cardType.label), serial)
                 }
             }
             return convertView

--- a/src/main/java/au/id/micolous/metrodroid/util/ExportHelper.kt
+++ b/src/main/java/au/id/micolous/metrodroid/util/ExportHelper.kt
@@ -2,7 +2,7 @@
  * ExportHelper.kt
  *
  * Copyright (C) 2011 Eric Butler <eric@codebutler.com>
- * Copyright 2018 Michael Farrell <micolous+git@gmail.com>
+ * Copyright 2018-2019 Michael Farrell <micolous+git@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -158,7 +158,7 @@ object ExportHelper {
     private fun importCard(c: Card,
                            context: Context): Uri? {
         val cv = ContentValues()
-        cv.put(CardsTableColumns.TYPE, c.cardType.toInteger())
+        cv.put(CardsTableColumns.TYPE, c.cardType.value)
         cv.put(CardsTableColumns.TAG_SERIAL, c.tagId.toHexString())
         cv.put(CardsTableColumns.DATA, CardSerializer.toPersist(c))
         cv.put(CardsTableColumns.SCANNED_AT, c.scannedAt.timeInMillis)

--- a/src/main/java/au/id/micolous/metrodroid/util/Preferences.kt
+++ b/src/main/java/au/id/micolous/metrodroid/util/Preferences.kt
@@ -38,6 +38,7 @@ actual object Preferences {
     const val PREF_LAST_READ_AT = "last_read_at"
     private const val PREF_MFC_AUTHRETRY = "pref_mfc_authretry"
     private const val PREF_MFC_FALLBACK = "pref_mfc_fallback"
+    private const val PREF_FELICA_ONLY_FIRST = "pref_felica_only_first"
     private const val PREF_RETRIEVE_LEAP_KEYS = "pref_retrieve_leap_keys"
 
     private const val PREF_HIDE_CARD_NUMBERS = "pref_hide_card_numbers"
@@ -176,6 +177,8 @@ actual object Preferences {
             TransitData.RawLevel.NONE.toString())) ?: TransitData.RawLevel.NONE
 
     val overrideLang get() = getStringPreference(PREF_LANG_OVERRIDE, "")
+
+    val felicaOnlyFirst get() = getBooleanPref(PREF_FELICA_ONLY_FIRST, false)
 
     actual val metrodroidVersion: String
         get() = BuildConfig.VERSION_NAME

--- a/src/main/res/layout/activity_add_key.xml
+++ b/src/main/res/layout/activity_add_key.xml
@@ -82,7 +82,7 @@
         android:layout_marginLeft="8dp"
         android:layout_marginRight="8dp"
         android:layout_marginStart="8dp"
-        android:text="@string/mifare_classic"
+        android:text="@string/card_media_mfc"
         android:textSize="16sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -123,7 +123,7 @@
     <string name="binary_title_format">Binärdaten</string>
     <string name="need_stations_submit">Melden</string>
     <string name="copied_to_clipboard">In die Zwischenablage kopiert</string>
-    <string name="mifare_classic">MIFARE Classic</string>
+    <string name="card_media_mfc">MIFARE Classic</string>
     <string name="obfuscation_card_numbers">Kartennummern ausblenden</string>
     <string name="obfuscation_card_numbers_desc">Kartennummern nirgendwo anzeigen</string>
     <string name="accessibility">Bedienungshilfen</string>
@@ -429,7 +429,7 @@
     <string name="classic_key_format">Schlüssel: %s</string>
     <string name="trip_counter">Fahrtenzähler</string>
     <string name="refill_counter">Nachfüllzähler</string>
-    <string name="mifare_desfire">MIFARE DESFire</string>
+    <string name="card_media_mfd">MIFARE DESFire</string>
     <string name="card_media_felica_lite">FeliCa Lite</string>
     <string name="raw_header">Rohfelder</string>
     <string name="android_nfc_settings">Android NFC-Einstellungen</string>

--- a/src/main/res/values-el/strings.xml
+++ b/src/main/res/values-el/strings.xml
@@ -115,7 +115,7 @@
     <string name="classic_key_format_a">Κλειδί (Α): %s</string>
     <string name="classic_key_format_b">Κλειδί (B): %s</string>
     <string name="classic_key_format">Κλειδί: %s</string>
-    <string name="mifare_desfire">MIFARE DESFire</string>
+    <string name="card_media_mfd">MIFARE DESFire</string>
     <string name="card_media_felica_lite">FeliCa Lite</string>
     <string name="card_format_ndef">NDEF</string>
     <string name="unknown_date_title">Άγνωστη ημερομηνία</string>

--- a/src/main/res/values-es/strings.xml
+++ b/src/main/res/values-es/strings.xml
@@ -121,7 +121,7 @@
     <string name="need_stations_submit">Reportar</string>
     <string name="about_card_format">Sobre este formato de tarjeta</string>
     <string name="online_services">Servicios en línea</string>
-    <string name="mifare_classic">MIFARE Classic</string>
+    <string name="card_media_mfc">MIFARE Classic</string>
     <string name="auth_retries">Reintentos de autenticación</string>
     <string name="auth_retries_summary">Número de veces para intentar la autenticación para cada sector</string>
     <string name="requires_android_17">Requiere Android 4.2 o posterior.</string>
@@ -576,7 +576,7 @@
     <string name="classic_key_format">Clave: %s</string>
     <string name="trip_counter">Contador de viajes</string>
     <string name="refill_counter">Contador de recargas</string>
-    <string name="mifare_desfire">MIFARE DESFire</string>
+    <string name="card_media_mfd">MIFARE DESFire</string>
     <string name="leap_period_start">Inicio del período</string>
     <string name="leap_accumulator_region">Región</string>
     <string name="leap_daily_accumulators">Límites de las tarifas diarias</string>

--- a/src/main/res/values-fr/strings.xml
+++ b/src/main/res/values-fr/strings.xml
@@ -94,7 +94,7 @@
     <string name="map_tiles_subdomains_summary">Si vous utilisez {s} dans les URL des cartes, une liste de sous-domaine séparés par une virgule, une liste de sous-domaines à caractère unique.</string>
     <string name="about_card_format">À propos de ce format de carte</string>
     <string name="online_services">Services en ligne</string>
-    <string name="mifare_classic">MIFARE Classic</string>
+    <string name="card_media_mfc">MIFARE Classic</string>
     <string name="auth_retries">Tentatives d\'authentification</string>
     <string name="auth_retries_summary">Nombre de tentatives d\'authentification pour chaque secteur</string>
     <string name="mfc_fallback_desc">Certaines agences n\'ont pas de système d\'identification sur leur carte. Pour les lire, vous devez sélectionner explicitement une agence.</string>
@@ -625,7 +625,7 @@
     <string name="classic_key_format">Clé : %s</string>
     <string name="trip_counter">Compteur de trajets</string>
     <string name="refill_counter">Compteur de recharges</string>
-    <string name="mifare_desfire">MIFARE DESFire</string>
+    <string name="card_media_mfd">MIFARE DESFire</string>
     <string name="leap_retrieve_keys">Récupération de clés pour les cartes Leap</string>
     <string name="leap_retrieve_keys_longdesc">Ceci partagera vos détails de carte avec Transport pour l’Irlande (TFI), afin de répondre à une requête d’authentification de la carte Leap. TFI sera en mesure de savoir que vous avez utilisé Metrodroid sur cette carte. La carte n’est pas lisible sans cette clé.</string>
     <string name="locked_leap">Leap verrouillé</string>

--- a/src/main/res/values-in/strings.xml
+++ b/src/main/res/values-in/strings.xml
@@ -111,7 +111,7 @@
     <string name="map_tiles_subdomains">Subdomain petak peta</string>
     <string name="map_tiles_subdomains_summary">Jika menggunakan {s} pada URLs peta, list subdomain dipisahkan dengan koma, atau dengan list subdomain dengan satu karakter.</string>
     <string name="online_services">Pelayanan online</string>
-    <string name="mifare_classic">MIFARE Classic</string>
+    <string name="card_media_mfc">MIFARE Classic</string>
     <string name="auth_retries">Ulang autentikasi</string>
     <string name="auth_retries_summary">Jumlah berapa kali percobaan autentikasi di tiap sektor</string>
 

--- a/src/main/res/values-it/strings.xml
+++ b/src/main/res/values-it/strings.xml
@@ -112,7 +112,7 @@
     <string name="file_exported">File esportato.</string>
     <string name="about_card_format">Informazioni su questo formato della carta</string>
     <string name="online_services">Servizi online</string>
-    <string name="mifare_classic">MIFARE Classic</string>
+    <string name="card_media_mfc">MIFARE Classic</string>
     <string name="requires_android_17">Richiede Android 4.2 o successivo.</string>
     <string name="requires_android_21">Richiede Android 5.0 o successivo.</string>
     <string name="card_reading_type">Lettura di <xliff:g id="card_name" example="Opal">%s</xliff:g>..…</string>
@@ -338,7 +338,7 @@
     <string name="classic_key_format">Chiave: %s</string>
     <string name="trip_counter">Contatore di viaggi</string>
     <string name="refill_counter">Contatore di ricarica</string>
-    <string name="mifare_desfire">MIFARE DESFire</string>
+    <string name="card_media_mfd">MIFARE DESFire</string>
     <string name="card_media_felica_lite">FeliCa Lite</string>
     <string name="felica_lite_read_only">Dati di sola lettura</string>
     <string name="felica_lite_read_write">Dati riscrivibili</string>

--- a/src/main/res/values-ja/strings.xml
+++ b/src/main/res/values-ja/strings.xml
@@ -177,7 +177,7 @@
     <string name="map_tiles_subdomains_summary">地図 URL に {s} を使用する場合は、カンマで区切られたサブドメインのリストか、サブドメインの 1 文字のリスト。</string>
     <string name="about_card_format">このカードフォーマットについて</string>
     <string name="online_services">オンライン サービス</string>
-    <string name="mifare_classic">MIFARE クラシック</string>
+    <string name="card_media_mfc">MIFARE クラシック</string>
     <string name="auth_retries">認証の再試行</string>
     <string name="auth_retries_summary">セクターごとに認証を試行する回数</string>
     <string name="valid_to_format">%1$s まで有効</string>

--- a/src/main/res/values-nb-rNO/strings.xml
+++ b/src/main/res/values-nb-rNO/strings.xml
@@ -101,7 +101,7 @@
     <string name="map_tiles_subdomains">Kartflis-underdomener</string>
     <string name="map_tiles_help">Vis Leaflet TileLayer-dokumentasjon</string>
     <string name="about_card_format">Om dette kortformatet</string>
-    <string name="mifare_classic">MIFARE Classic</string>
+    <string name="card_media_mfc">MIFARE Classic</string>
     <string name="auth_retries_summary">Antall ganger autentisering skal forsøkes for hver sektor</string>
     <string name="mfc_fallback_desc">Noen byrå har ingen identifiserende magi på kortene sine. For å lese dem, må du eksplisitt velge et byrå.</string>
     <string name="mfc_fallback">Tilbakefallsleser</string>
@@ -487,7 +487,7 @@
     <string name="desfire_key_number">Nøkkel %s</string>
     <string name="location_ireland">Irland</string>
     <string name="location_minneapolis">Minneapolis, MN, USA</string>
-    <string name="mifare_desfire">MIFARE DESFire</string>
+    <string name="card_media_mfd">MIFARE DESFire</string>
     <string name="leap_retrieve_keys">Hent nøkler for Leap-kort</string>
     <string name="leap_retrieve_keys_longdesc">Dette vil dele dine kortdetaljer med Transport for Irland, for å kunne besvare Leap-kortets identitetsbekreftelsesutfordring. TFI vil kunne vite at du brukte Metrodroid på dette kortet. Kortet er ikke lesbart uten denne nøkkelen.</string>
     <string name="locked_leap">Låst Leap</string>

--- a/src/main/res/values-nl/strings.xml
+++ b/src/main/res/values-nl/strings.xml
@@ -94,7 +94,7 @@
     <string name="map_tiles_subdomains_summary">Als je {s} gebruikt in kaartURL\'s, een kommagescheiden lijst van subdomeinen of een losse tekenlijst van subdomeinen.</string>
     <string name="about_card_format">Over dit kaartformaat</string>
     <string name="online_services">Online diensten</string>
-    <string name="mifare_classic">MIFARE Classic</string>
+    <string name="card_media_mfc">MIFARE Classic</string>
     <string name="auth_retries">Authentiecatiepogingen</string>
     <string name="auth_retries_summary">Aantal keren om te proberen elke sector te authenticeren</string>
     <string name="mfc_fallback_desc">Sommige vervoerders hebben geen magische identificatie op hun kaart. Om ze uit te lezen moet je er expliciet één kiezen.</string>
@@ -490,7 +490,7 @@
     <string name="desfire_keyex">Sleuteluitwisseling</string>
     <string name="desfire_key_number">Sleutel %s</string>
     <string name="location_ireland">Ierland</string>
-    <string name="mifare_desfire">MIFARE DESFire</string>
+    <string name="card_media_mfd">MIFARE DESFire</string>
     <string name="leap_retrieve_keys">Sleutels ophalen voor Leap-kaarten</string>
     <string name="leap_retrieve_keys_longdesc">Dit deelt je kaartgegevens met Transport for Ireland, zodat er kan worden geantwoord op de authenticatie-uitdaging van de Leap-kaart. TfI zal te weten komen dat je Metrodroid hebt gebruikt. Zonder deze sleutel is de kaart onleesbaar.</string>
     <string name="locked_leap">Vergrendelde Leap-kaart</string>

--- a/src/main/res/values-pt-rBR/strings.xml
+++ b/src/main/res/values-pt-rBR/strings.xml
@@ -120,7 +120,7 @@
     <string name="file_exported">Arquivo exportado.</string>
     <string name="about_card_format">Sobre este formato de cartão</string>
     <string name="online_services">Serviços online</string>
-    <string name="mifare_classic">MIFARE Classic</string>
+    <string name="card_media_mfc">MIFARE Classic</string>
     <string name="auth_retries">Tentativas de autenticação</string>
     <string name="auth_retries_summary">Número de vezes para tentar autenticação para cada setor</string>
     <string name="requires_android_17">Requer o Android 4.2 ou posterior.</string>

--- a/src/main/res/values-ru/strings.xml
+++ b/src/main/res/values-ru/strings.xml
@@ -172,7 +172,7 @@
     <string name="saved_xml_custom">Файл XML записан на USB носитель.</string>
     <string name="about_card_format">Об этом формате карт</string>
     <string name="online_services">Онлайн сервисы</string>
-    <string name="mifare_classic">MIFARE Classic</string>
+    <string name="card_media_mfc">MIFARE Classic</string>
     <string name="auth_retries">Количество попыток аутентификации</string>
     <string name="auth_retries_summary">Количество попыток аутентификации для каждого сектора</string>
     <string name="mfc_fallback_desc">На картах некоторых транспортных компаний нету идентификатора. Чтобы их прочитать вам нужно выбрать транспортную компанию явно.</string>
@@ -414,7 +414,7 @@
     <string name="card_name_troika_strelka_hybrid">Тройка+Стрелка</string>
     <string name="trip_counter">Счетчик поездок</string>
     <string name="refill_counter">Счётчик пополнений</string>
-    <string name="mifare_desfire">MIFARE DESFire</string>
+    <string name="card_media_mfd">MIFARE DESFire</string>
     <string name="leap_retrieve_keys">Скачать ключи для карты Leap</string>
     <string name="leap_retrieve_keys_longdesc">При этом данные вашей карты будут переданы в Transport for Ireland для того, чтобы разблокировать карту Leap. TFI сможет узнать, что вы использовали Metrodroid на этой карте. Карточка не сможет быть прочитана без этого ключа.</string>
     <string name="leap_period_start">Начало периода</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -235,7 +235,6 @@
     <string name="map_tiles_help_summary">For help on using map tile URLs, see Leaflet\'s online documentation (only available in English).</string>
     <string name="about_card_format">About this card format</string>
     <string name="online_services">Online services</string>
-    <string name="mifare_classic">MIFARE Classic</string>
     <string name="auth_retries">Authentication retries</string>
     <string name="auth_retries_summary">Number of times to attempt authentication for each sector</string>
 
@@ -1983,11 +1982,37 @@
     <string name="classic_key_format">Key: %s</string>
     <string name="trip_counter">Trips counter</string>
     <string name="refill_counter">Refill counter</string>
-    <string name="mifare_desfire">MIFARE DESFire</string>
+
+    <!-- Card media types -->
+
+    <!--
+    Translators:
+    Used to describe a card media type in a list of cards.
+    %1$s is replaced with the type of card media (card_media_*)
+    %2$s is replaced with the serial number of the card
+    -->
+    <string name="card_media_placeholder" translatable="false"><xliff:g id="card_media" example="FeliCa">%1$s</xliff:g> - <xliff:g id="serial_number" example="A1B2C3D4">%2$s</xliff:g></string>
+    <!-- Type of card media; "Contactless e-Purse Application Specification" -->
+    <string name="card_media_cepas">CEPAS</string>
     <!-- Translators: type of card media (フェリカ / Felicity Card) -->
     <string name="card_media_felica">FeliCa</string>
     <!-- Translators: type of card media, variant of FeliCa (フェリカ / Felicity Card) -->
     <string name="card_media_felica_lite">FeliCa Lite</string>
+    <!-- Card protocol -->
+    <string name="card_media_iso7816">ISO/IEC 7816</string>
+    <!-- Type of card media -->
+    <string name="card_media_mfc">MIFARE Classic</string>
+    <!-- Type of card media -->
+    <string name="card_media_mfd">MIFARE DESFire</string>
+    <!-- Type of card media -->
+    <string name="card_media_mfp">MIFARE Plus</string>
+    <!-- Type of card media -->
+    <string name="card_media_mfu">MIFARE Ultralight</string>
+    <!-- Used to describe a card that communicates with multiple protocols -->
+    <string name="card_media_multi_protocol">Multi-protocol</string>
+    <!-- Type of card media; ISO 15693 "Vicinity" (do not literally translate) -->
+    <string name="card_media_vicinity">Vicinity</string>
+
     <string name="felica_lite_read_only">Read-only data</string>
     <string name="felica_lite_read_write">Re-writable data</string>
     <!-- Translators: NDEF = NFC Data Exchange Format -->

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1984,6 +1984,8 @@
     <string name="trip_counter">Trips counter</string>
     <string name="refill_counter">Refill counter</string>
     <string name="mifare_desfire">MIFARE DESFire</string>
+    <!-- Translators: type of card media (フェリカ / Felicity Card) -->
+    <string name="card_media_felica">FeliCa</string>
     <!-- Translators: type of card media, variant of FeliCa (フェリカ / Felicity Card) -->
     <string name="card_media_felica_lite">FeliCa Lite</string>
     <string name="felica_lite_read_only">Read-only data</string>
@@ -1993,6 +1995,28 @@
     <!-- Translators: area of card storage shared by Suica and Edy,
          possibly othewr systems as well. -->
     <string name="felica_system_common">Common Area (FeliCa Networks)</string>
+    <!--
+    Translators:
+    Used as a preference title. FeliCa divides cards into "systems" (~applications) and "services"
+    (~files). A single card may have more than one "system".
+
+    By default, this preference is disabled: Metrodroid reads all systems from a FeliCa card.
+
+    When this preference is enabled, Metrodroid will only read the first system on a FeliCa card.
+    -->
+    <string name="felica_first_system_pref">Only read first system</string>
+    <!--
+    Translators:
+    See 'felica_first_system_pref' for explanation of the preference.
+    This is used as a summary when the preference is disabled (default).
+    -->
+    <string name="felica_first_system_pref_summary_off">Metrodroid will read all systems on FeliCa cards. This is the default.</string>
+    <!--
+    Translators:
+    See 'felica_first_system_pref' for explanation of the preference.
+    This is used as a summary when the preference is enabled.
+    -->
+    <string name="felica_first_system_pref_summary_on">Metrodroid will read only the first system on FeliCa cards. This simulates a workaround for a bug in iOS. Reads of multi-system FeliCa cards will be incomplete!</string>
 
     <!-- TFI Leap -->
     <string name="leap_retrieve_keys">Retrieve keys for Leap cards</string>

--- a/src/main/res/xml/prefs.xml
+++ b/src/main/res/xml/prefs.xml
@@ -202,6 +202,15 @@
                 android:key="pref_obfuscate_trip_fares"
                 android:defaultValue="false" />
         </PreferenceCategory>
+
+        <PreferenceCategory android:title="@string/card_media_felica">
+            <CheckBoxPreference
+                android:title="@string/felica_first_system_pref"
+                android:summaryOff="@string/felica_first_system_pref_summary_off"
+                android:summaryOn="@string/felica_first_system_pref_summary_on"
+                android:key="pref_felica_only_first"
+                android:defaultValue="false" />
+        </PreferenceCategory>
     </PreferenceScreen>
     </PreferenceCategory>
 </PreferenceScreen>

--- a/src/main/res/xml/prefs.xml
+++ b/src/main/res/xml/prefs.xml
@@ -97,7 +97,7 @@
                     android:title="@string/android_nfc_settings" />
             </PreferenceCategory>
 
-            <PreferenceCategory android:title="@string/mifare_classic">
+            <PreferenceCategory android:title="@string/card_media_mfc">
                 <au.id.micolous.metrodroid.ui.NumberPickerPreference
                     android:title="@string/auth_retries"
                     android:summary="@string/auth_retries_summary"
@@ -116,7 +116,7 @@
                     />
             </PreferenceCategory>
 	    
-	        <PreferenceCategory android:title="@string/mifare_desfire">
+	        <PreferenceCategory android:title="@string/card_media_mfd">
                 <CheckBoxPreference
                     android:title="@string/leap_retrieve_keys"
                     android:summary="@string/leap_retrieve_keys_longdesc"


### PR DESCRIPTION
Built on #672 and #676.

* Adds `card_media_*` strings to describe supported card types
* Renames `mifare_classic` to `card_media_mfc`, `mifare_desfire` to `card_media_mfd` for consistency
* Uses this to describe card information

**TODO**

* [x] Merge #672
* [x] Merge #676 
* [ ] Merge various Android codepaths that use this
* [ ] Fix iOS serial display