### PR TITLE
mct_to_mfcdump.py: add null bytes when bytes are unknown

### DIFF
--- a/extra/mct_to_mfcdump.py
+++ b/extra/mct_to_mfcdump.py
@@ -59,6 +59,11 @@ def mct_to_mfc(input_f, output_f):
       else:
         line = DUMMY_TRAILER_BLOCK
 
+    if '--' in line:
+      line = line.replace('--', '00')
+      print("Replaced placeholder bytes at sector %d block %d with NULL" % (
+        sector, block))
+
     line = b16decode(line)
     output_f.write(line)
     block += 1


### PR DESCRIPTION
This is what `MctCardImporter` does.

This is needed when you have a dump from MCT where Key B was unknown or unreadable, eg:

`A1A2A3A4A5A678778869------------`