### PR TITLE
WIP: ISO7816/CEPAS speed-ups to make Android Pay work

### DIFF
--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/cepas/CEPASApplication.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/cepas/CEPASApplication.kt
@@ -123,8 +123,6 @@ data class CEPASApplication(
             var isValid = false
             val numPurses = 16
 
-            capsule.dumpAllSfis(iso7816Tag, feedbackInterface, 0, 32)
-
             val cepasTag = CEPASProtocol(iso7816Tag)
 
             try {

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/iso7816/ISO7816Exception.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/iso7816/ISO7816Exception.kt
@@ -9,3 +9,6 @@ open class ISO7816Exception : Exception {
 class ISOEOFException : ISO7816Exception("End of file")
 class ISOFileNotFoundException : ISO7816Exception("File not found")
 class ISONoCurrentEF : ISO7816Exception("No current EF")
+class ISOInstructionCodeNotSupported : ISO7816Exception("Instruction code not supported")
+class ISOClassNotSupported: ISO7816Exception("Class not supported")
+class ISOSecurityStatusNotSatisfied: ISO7816Exception("Security status not satisfied")

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/iso7816/ISO7816Protocol.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/iso7816/ISO7816Protocol.kt
@@ -133,6 +133,9 @@ class ISO7816Protocol(private val mTagTech: CardTransceiver) {
                     ->
                         // Emitted by Android HCE when doing a CEPAS probe
                         throw ISONoCurrentEF()
+                    CNA_SECURITY_STATUS_NOT_SATISFIED
+                        // Emitted by CEPAS on SFI=3 before app selection
+                    -> throw ISOSecurityStatusNotSatisfied()
                 }
 
                 ERROR_WRONG_PARAMETERS // Wrong Parameters P1 - P2
@@ -142,6 +145,12 @@ class ISO7816Protocol(private val mTagTech: CardTransceiver) {
                     WP_RECORD_NOT_FOUND // Record not found
                     -> throw ISOEOFException()
                 }
+
+                ERROR_INS_NOT_SUPPORTED_OR_INVALID // Instruction code not supported or invalid
+                -> throw ISOInstructionCodeNotSupported()
+
+                ERROR_CLASS_NOT_SUPPORTED
+                -> throw ISOClassNotSupported()
             }
 
             // we get error?
@@ -254,7 +263,13 @@ class ISO7816Protocol(private val mTagTech: CardTransceiver) {
         @VisibleForTesting
         const val ERROR_WRONG_LENGTH = 0x6C.toByte()
         @VisibleForTesting
+        const val ERROR_INS_NOT_SUPPORTED_OR_INVALID = 0x6D.toByte()
+        @VisibleForTesting
+        const val ERROR_CLASS_NOT_SUPPORTED = 0x6E.toByte()
+        @VisibleForTesting
         const val CNA_NO_CURRENT_EF = 0x86.toByte()
+        @VisibleForTesting
+        const val CNA_SECURITY_STATUS_NOT_SATISFIED = 0x82.toByte()
         @VisibleForTesting
         const val WP_FILE_NOT_FOUND = 0x82.toByte()
         @VisibleForTesting


### PR DESCRIPTION
* CEPAS: removes early `dumpAllSfis`.  This saves about 1.6 sec reading CEPAS and EMV cards.  The data here is never actually used by Metrodroid as far as I can tell, and it is _also_ available in other places:

  * SFI 16 = `:3f00:4000:10`
  * SFI 22 = `:3f00:4000:16`
  * SFI 23 = `:3f00:4000:17`

* EMV: Makes the GPO authorised for USD 0.00, rather than USD 0.01
* ISO: Add some more error conditions, and bail out earlier on `file not found` and `security status not satisfied`
* EMV: Bail out early when reading if the first batch of SFIs returns null 3/3, rather than continuing to read (which helps with Android Pay)

This seems to be good enough to let `jvmcli` sort-of read from Android Pay EMV -- it does time out in a later stage, but pulling the phone away from the reader still shows valid data.

I'm still able to read a CEPAS not affected by #366 in jvmcli with this patch.

I still need to do some more testing on this to ensure nothing else broke.