### PR TITLE
felica: Add Request Specification Version, show raw response and PMm on raw data view

### DIFF
--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/felica/FelicaConsts.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/felica/FelicaConsts.kt
@@ -81,6 +81,10 @@ object FelicaConsts {
     const val COMMAND_WRITE: Byte = 0x16
     const val RESPONSE_WRITE: Byte = 0x17
 
+    // Request Specification Version (s4.4.15)
+    const val COMMAND_REQUEST_SPECIFICATION_VERSION: Byte = 0x3c
+    const val RESPONSE_REQUEST_SPECIFICATION_VERSION: Byte = 0x3d
+
     // Reset Mode (s4.4.16)
     const val COMMAND_RESET_MODE: Byte = 0x3e
     const val RESPONSE_RESET_MODE: Byte = 0x3f

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/card/felica/FelicaReader.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/card/felica/FelicaReader.kt
@@ -31,6 +31,7 @@ import au.id.micolous.metrodroid.multi.Log
 import au.id.micolous.metrodroid.multi.R
 import au.id.micolous.metrodroid.transit.CardInfo
 import au.id.micolous.metrodroid.transit.octopus.OctopusTransitData
+import au.id.micolous.metrodroid.util.ImmutableByteArray
 import au.id.micolous.metrodroid.util.hexString
 
 
@@ -97,6 +98,7 @@ object FelicaReader {
         var actionsDone = 0
         var totalActions = 1
         feedbackInterface.updateProgressBar(actionsDone, totalActions)
+        var specificationVersion: ImmutableByteArray? = null
 
         try {
             var codes = fp.getSystemCodeList().toMutableList()
@@ -133,6 +135,9 @@ object FelicaReader {
                 feedbackInterface.updateStatusText(Localizer.localizeString(R.string.card_reading_type, i.name))
                 feedbackInterface.showCardType(i)
             }
+
+            // Some cards don't support this, we just swallow the exception and move on.
+            specificationVersion = fp.requestSpecificationVersion(0)
 
             for ((systemNumber, systemCode) in codes.withIndex()) {
                 Log.d(TAG, "System code #$systemNumber: ${systemCode.hexString}")
@@ -237,6 +242,6 @@ object FelicaReader {
             Log.w(TAG, "Could not detect any systems on the card!")
         }
 
-        return FelicaCard(pmm, systems, isPartialRead = partialRead)
+        return FelicaCard(pmm, systems, specificationVersion, isPartialRead = partialRead)
     }
 }

--- a/src/commonTest/assets/felica/felica-spec-version-aes-only.json
+++ b/src/commonTest/assets/felica/felica-spec-version-aes-only.json
@@ -1,0 +1,22 @@
+{
+  "tagId": "0101010101010101",
+  "scannedAt": {
+    "timeInMillis": 1575771030000,
+    "tz": "Australia/Sydney"
+  },
+  "felica": {
+    "pMm": "053143454682b7ff",
+    "systems": {
+      3: {
+        "services": {
+          1: {
+            "blocks": [
+              {"data": "00000000000000000000000000000000"}
+            ]
+          }
+        }
+      }
+    },
+    "specificationVersion": "00008500"
+  }
+}

--- a/src/commonTest/assets/felica/felica-spec-version-des.json
+++ b/src/commonTest/assets/felica/felica-spec-version-des.json
@@ -1,0 +1,22 @@
+{
+  "tagId": "0101010101010101",
+  "scannedAt": {
+    "timeInMillis": 1575770900000,
+    "tz": "Australia/Sydney"
+  },
+  "felica": {
+    "pMm": "053143454682b7ff",
+    "systems": {
+      3: {
+        "services": {
+          1: {
+            "blocks": [
+              {"data": "00000000000000000000000000000000"}
+            ]
+          }
+        }
+      }
+    },
+    "specificationVersion": "000085010085"
+  }
+}

--- a/src/commonTest/kotlin/au/id/micolous/metrodroid/test/FelicaJsonImportTest.kt
+++ b/src/commonTest/kotlin/au/id/micolous/metrodroid/test/FelicaJsonImportTest.kt
@@ -62,7 +62,9 @@ class FelicaJsonImportTest: CardReaderWithAssetDumpsTest(JsonKotlinFormat)  {
      */
     @Test
     fun testIdm() {
-        checkLoadCard("felica/felica-idm.json")
+        val felica = checkLoadCard("felica/felica-idm.json")
+        assertNull(felica.basicVersion)
+        assertNull(felica.optionVersions)
     }
 
     /**
@@ -70,7 +72,33 @@ class FelicaJsonImportTest: CardReaderWithAssetDumpsTest(JsonKotlinFormat)  {
      */
     @Test
     fun testNoIdm() {
-        checkLoadCard("felica/felica-no-idm.json")
+        val felica = checkLoadCard("felica/felica-no-idm.json")
+        assertNull(felica.basicVersion)
+        assertNull(felica.optionVersions)
+    }
+
+    /**
+     * Test reading a FeliCa JSON dump with specificationVersion tag (like >= v3.1.0)
+     *
+     * This card does not have any optional version data (AES-only card).
+     */
+    @Test
+    fun testSpecificationVersionAESOnly() {
+        val felica = checkLoadCard("felica/felica-spec-version-aes-only.json")
+        assertEquals(500, felica.basicVersion)
+        assertEquals(emptyList(), felica.optionVersions)
+    }
+
+    /**
+     * Test reading a FeliCa JSON dump with specificationVersion tag (like >= v3.1.0)
+     *
+     * This card has optional version data (so supports DES).
+     */
+    @Test
+    fun testSpecificationVersionDES() {
+        val felica = checkLoadCard("felica/felica-spec-version-des.json")
+        assertEquals(500, felica.basicVersion)
+        assertEquals(listOf(500), felica.optionVersions)
     }
 
     /**

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -638,6 +638,10 @@
     <!-- Translators: "Issuance" is the name of group of FeliCa commands -->
     <string name="felica_response_time_other">Issuance commands</string>
 
+    <string name="felica_specification_version">Specification version</string>
+    <string name="felica_basic_version">Basic specification version</string>
+    <string name="felica_option_version_list">Optional version list</string>
+
     <!-- Calypso hardware information -->
     <string name="calypso_serial_number">Serial number</string>
     <string name="calypso_manufacture_country">Country of manufacture</string>


### PR DESCRIPTION
For FeliCa as part of dumping process, this change sends a `Request Specification Version` command. This contains the FeliCa specification version that a card supports, and also indicates whether a card supports DES (no `option versions` = no DES).

I've tested this with various Japanese IC cards -- the only "weirdness" was that my PASMO does not respond to it at all; so I wrapped up the `CardLostException` (similar to a number of other fallback mechanisms we use on FeliCa).

I added support for propagating up `CardLostException` from `JavaFelicaTransceiver`, which was needed to read the PASMO correctly with the ACR122.  This class already hard codes a bunch of ACR122/PN532-specific code (using ACR122 `Escape` + PN532 `InDataExchange`); I've got already got another branch starting to unravel this.

Existing dumps (that lack this field) won't display any Specification Version data.  I've added tests for this.

While here, this adds the raw data for this and the PMm to the Raw Data view.

**Tests:**

* Android works fine with 5 different Japan IC cards
* Java + ACR122 works fine with 5 different Japan IC cards
* iOS 13.2.3 iPhone 7 works fine with 5 different Japan IC cards

I wasn't able to test with this with _FeliCa Lite_ tags -- I've misplaced mine. 😞 
