### PR TITLE
Clipper: Fix vehicle numbers for LRV4 Muni Vehicles

### DIFF
--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/clipper/ClipperTrip.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/clipper/ClipperTrip.kt
@@ -66,7 +66,13 @@ class ClipperTrip (private val mTimestamp: Long,
         } else null
 
     override val vehicleID: String?
-        get() = if (mVehicleNum != 0 && mVehicleNum != 0xffff) mVehicleNum.toString() else null
+        get() = when (mVehicleNum) {
+            0, 0xffff -> null
+            in 1..9999 -> mVehicleNum.toString()
+            // For LRV4 Muni vehicles with newer Clipper readers, it stores a 4-digit vehicle number followed
+            // by a letter. For example 0d20461 is vehicle number 2046A, 0d20462 is 2046B, and so on.
+            else -> (mVehicleNum / 10).toString() + Integer.toHexString((mVehicleNum % 10) + 9).toString().toUpperCase()
+        }
 
     override val fare: TransitCurrency?
         get() = TransitCurrency.USD(mFare)

--- a/src/commonTest/kotlin/au/id/micolous/metrodroid/test/ClipperTest.kt
+++ b/src/commonTest/kotlin/au/id/micolous/metrodroid/test/ClipperTest.kt
@@ -25,6 +25,7 @@ import au.id.micolous.metrodroid.time.TimestampFull
 import au.id.micolous.metrodroid.transit.TransitCurrency
 import au.id.micolous.metrodroid.transit.Trip
 import au.id.micolous.metrodroid.transit.clipper.ClipperTransitData
+import au.id.micolous.metrodroid.transit.clipper.ClipperTrip
 import au.id.micolous.metrodroid.util.ImmutableByteArray
 import kotlin.test.*
 
@@ -103,6 +104,17 @@ class ClipperTest : BaseInstrumentedTest() {
         assertEquals("Dublin/Pleasanton", trips[0].endStation!!.getStationName(true).unformatted)
         assertNear(37.70169, trips[0].endStation!!.latitude!!.toDouble(), 0.00001)
         assertNear(-121.89918, trips[0].endStation!!.longitude!!.toDouble(), 0.00001)
+    }
+
+    @Test
+    fun testVehicleNumbers() {
+        assertEquals(null, ClipperTrip(ImmutableByteArray.fromHex("0000000000000000000000000000000000000000000000000000000000000000")).vehicleID)
+        assertEquals(null, ClipperTrip(ImmutableByteArray.fromHex("00000000000000000000ffff0000000000000000000000000000000000000000")).vehicleID)
+        // These trips below were extracted from an actual clipper card
+        assertEquals("1058", ClipperTrip(ImmutableByteArray.fromHex("10000012000000fa008a0422e1a11e84000000000000ffffff00000000010061")).vehicleID)
+        assertEquals("2010A", ClipperTrip(ImmutableByteArray.fromHex("10000012000000fa008a4e85e1a0ff9a000000000000ffff0000000000010075")).vehicleID)
+        assertEquals("2061B", ClipperTrip(ImmutableByteArray.fromHex("10000012000000fa008a5084e19ce9c1000000000000ffff0000000000010075")).vehicleID)
+        assertEquals("1525", ClipperTrip(ImmutableByteArray.fromHex("10000012000000fa008a05f5e1a01426000000000000ffffff00000000010061")).vehicleID)
     }
 
     companion object {


### PR DESCRIPTION
Historically, Muni just stored a 4-digit (decimal) vehicle number as part of a
Trip record on the Clipper Card. Muni rolled out a line of new LRV4 Light Rail
cars a while ago with newer Clipper Card readers. These readers also store
which car you are in (A vs B) for multi-car trains, in addition to the 4-digit
vehicle number, but as an extra decimal digit at the end, mapping 0d1 => A, 0d2
=> B, etc. For example, vehicle number 2046A is stored as 0d20461 (0x3fed),
2046B is stored as 0d20462 (0x4fee), etc.

This change modifies the ClipperTrip vehicleID method to take this into account
and adds some tests for it along the way.

The Trip rows come from an actual Clipper card that I've been using.