### PR TITLE
Fix Travis CI builds

### DIFF
--- a/.travis/start_android_emulator.sh
+++ b/.travis/start_android_emulator.sh
@@ -9,8 +9,7 @@ fi
 echo "** Starting emulator in background..."
 if [[ "${EMULATOR_ARCH}" =~ "x86" ]]
 then
-    EMULATOR="${EMULATOR}-headless"
-    EMULATOR_ARGS="${EMULATOR_ARGS} -no-accel"
+    EMULATOR_ARGS="${EMULATOR_ARGS} -no-accel -no-window"
 fi
 
 ${EMULATOR} -avd "emu" \


### PR DESCRIPTION
Google Emulator 29.2.11 made some changes to their CLI API. From
https://androidstudio.googleblog.com/2019/12/emulator-29211-and-amd-hypervisor-12-to.html

> The binary emulator-headless is now retired. Headless builds of the engine
> are now launched via emulator -no-window, thus unifying the previously
> separate (but similar) paths.

This change modifies one of the Travis CI scripts to pick up this change. I
tested this on my private Travis CI build and it seemed to fix things.