### PR TITLE
seq_go: Use agency names from mdst (except Airtrain)

### DIFF
--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/seq_go/SeqGoData.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/seq_go/SeqGoData.kt
@@ -21,6 +21,7 @@ package au.id.micolous.metrodroid.transit.seq_go
 
 import au.id.micolous.metrodroid.multi.R
 import au.id.micolous.metrodroid.multi.StringResource
+import au.id.micolous.metrodroid.multi.VisibleForTesting
 
 /**
  * Constants used in Go card
@@ -29,11 +30,12 @@ object SeqGoData {
     const val SEQ_GO_STR = "seq_go"
 
     internal const val VEHICLE_RAIL = 5
-    internal const val VEHICLE_FERRY = 18
 
-    /* Hard coded station IDs for Airtrain; used in tests */
+    /* Airtrain */
+    @VisibleForTesting
     internal const val DOMESTIC_AIRPORT = 9
-    internal const val INTERNATIONAL_AIRPORT = 10
+    private const val INTERNATIONAL_AIRPORT = 10
+    internal val AIRPORT_STATIONS = listOf(DOMESTIC_AIRPORT, INTERNATIONAL_AIRPORT)
 
     // https://github.com/micolous/metrodroid/wiki/Go-(SEQ)#ticket-types
     // TODO: Discover child and seniors card type.

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/seq_go/SeqGoTrip.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/seq_go/SeqGoTrip.kt
@@ -22,8 +22,7 @@ import au.id.micolous.metrodroid.multi.FormattedString
 import au.id.micolous.metrodroid.multi.Parcelize
 import au.id.micolous.metrodroid.transit.nextfare.NextfareTrip
 import au.id.micolous.metrodroid.transit.nextfare.NextfareTripCapsule
-import au.id.micolous.metrodroid.transit.seq_go.SeqGoData.DOMESTIC_AIRPORT
-import au.id.micolous.metrodroid.transit.seq_go.SeqGoData.INTERNATIONAL_AIRPORT
+import au.id.micolous.metrodroid.transit.seq_go.SeqGoData.AIRPORT_STATIONS
 
 /**
  * Represents trip events on Go Card.
@@ -36,18 +35,12 @@ class SeqGoTrip (override val capsule: NextfareTripCapsule): NextfareTrip() {
     override val str: String?
         get() = SeqGoData.SEQ_GO_STR
 
-    override fun getAgencyName(isShort: Boolean) = FormattedString.language(
-            when (capsule.mModeInt) {
-                SeqGoData.VEHICLE_FERRY -> "Transdev Brisbane Ferries"
-                SeqGoData.VEHICLE_RAIL -> if (
-                        capsule.mStartStation == DOMESTIC_AIRPORT ||
-                        capsule.mEndStation == DOMESTIC_AIRPORT ||
-                        capsule.mStartStation == INTERNATIONAL_AIRPORT ||
-                        capsule.mEndStation == INTERNATIONAL_AIRPORT) {
-                    "Airtrain"
-                } else {
-                    "Queensland Rail"
-                }
-                else -> "TransLink"
-        }, "en-AU")
+    override fun getAgencyName(isShort: Boolean) =
+        if (capsule.mModeInt == SeqGoData.VEHICLE_RAIL && (
+                AIRPORT_STATIONS.contains(capsule.mStartStation) ||
+                    AIRPORT_STATIONS.contains(capsule.mEndStation))) {
+            FormattedString.language("Airtrain", "en-AU")
+        } else {
+            super.getAgencyName(isShort)
+        }
 }


### PR DESCRIPTION
* Uses agency name from mDST
* Refactor "Airtrain" code to be minimal for handling their stations