### PR TITLE
Deterministically serialize the MdST

### DIFF
--- a/extra/mdst/compile_stops_from_gtfs.py
+++ b/extra/mdst/compile_stops_from_gtfs.py
@@ -36,7 +36,7 @@ def massage_name(name, suffixes):
   for suffix in suffixes:
     if name.lower().endswith(suffix):
       name = name[:-len(suffix)].strip()
-  
+
   return name
 
 def empty(s):
@@ -227,7 +227,7 @@ def compile_stops_from_gtfs(input_gtfs_f, output_f, all_matching_f=None, version
 
 def main():
   parser = ArgumentParser()
-  
+
   parser.add_argument('-o', '--output',
     required=True,
     help='Output data file (MdST)'
@@ -237,7 +237,7 @@ def main():
     nargs='+',
     type=FileType('rb'),
     help='Path to GTFS ZIP file to extract data from.')
-  
+
   parser.add_argument('-m', '--matching',
     required=False,
     action='append',

--- a/extra/mdst/compile_stops_from_gtfs.py
+++ b/extra/mdst/compile_stops_from_gtfs.py
@@ -23,9 +23,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import print_function
 from argparse import ArgumentParser, FileType
-from datetime import datetime, timedelta
-from gtfstools import Gtfs, GtfsDialect
-from stations_pb2 import Station, Operator, TransportType, Line
+from datetime import datetime
+from gtfstools import Gtfs
+from stations_pb2 import Station, Line
 import mdst
 import codecs, csv
 

--- a/extra/mdst/compile_stops_from_gtfs.py
+++ b/extra/mdst/compile_stops_from_gtfs.py
@@ -164,7 +164,6 @@ def compile_stops_from_gtfs(input_gtfs_f, output_f, all_matching_f=None, version
         used = False
 
         # Insert rows where a stop_id is specified for the reader_id
-        stop_rows = []
         for reader_id in stop_ids.get(stop.get('stop_id', 'stop_id_absent'), []):
           s = Station()
           s.id = int(reader_id, 0)
@@ -182,7 +181,6 @@ def compile_stops_from_gtfs(input_gtfs_f, output_f, all_matching_f=None, version
           used = True
 
         # Insert rows where a stop_code is specified for the reader_id
-        stop_rows = []
         for reader_id in stop_codes.get(stop.get('stop_code', 'stop_code_absent'), []):
           s = Station()
           s.id = int(reader_id, 0)

--- a/extra/mdst/mdst.py
+++ b/extra/mdst/mdst.py
@@ -30,7 +30,7 @@ SCHEMA_VER = 1
 
 def delimited_value(msg):
   # Emits a writeDelimited compatible Protobuf message
-  o = msg.SerializeToString()
+  o = msg.SerializeToString(deterministic=True)
   d = encoder._VarintBytes(len(o))
   return d + o
 

--- a/extra/mdst/mdst.py
+++ b/extra/mdst/mdst.py
@@ -39,9 +39,9 @@ class MdstWriter(object):
   def __init__(self, fh, version, local_languages=None, operators=None, lines=None, tts_hint_language=None, license_notice_f=None):
     """
     Creates a new MdST database.
-    
+
     This class must be initialised with the parameters in the StationDb header.
-    
+
     fh: required, file-like object to write to.
     version: required, this is a numeric revision number for the database.
     local_languages: optional, list of languages which should be treated as "local".
@@ -49,14 +49,14 @@ class MdstWriter(object):
     lines: optional, dict of [int](Line) declaring a mapping of lines.
     tts_hint_language: optional, str of LocaleSpan hint for station names.
     license_notice_f: optional, file-like object containing a license notice.
-    
-    
+
+
     """
     sdb = StationDb()
     sdb.version = version
     if tts_hint_language:
       sdb.tts_hint_language = tts_hint_language
-    
+
     if local_languages:
       for l in local_languages:
         sdb.local_languages.append(l)
@@ -96,7 +96,7 @@ class MdstWriter(object):
     fh.write(b'MdST')
     fh.write(struct.pack('!II', SCHEMA_VER, 0))
     fh.write(delimited_value(sdb))
-    
+
     self.stationlist_off = fh.tell()
     self.fh = fh
     self.stations = {}
@@ -119,14 +119,14 @@ class MdstWriter(object):
     for station_id, offset in sorted(self.stations.items(), key=itemgetter(0)):
       sidx.station_map[station_id] = offset
     self.fh.write(delimited_value(sidx))
-    
+
     index_end_off = self.fh.tell()
 
     # Write the location of the index
     self.fh.seek(4+4)
     self.fh.write(struct.pack('!I', self.index_off - self.stationlist_off))
     self.fh.close()
-    
+
     return index_end_off
 
 
@@ -158,7 +158,7 @@ def read_stops_from_csv(db, csv_f):
 def read_operators_from_csv(csv_f):
   operators = {}
   opread = csv.DictReader(csv_f)
-    
+
   for op in opread:
     oppb = Operator()
     oppb.name.english = op['name']


### PR DESCRIPTION
Git becomes a lot more useful when files don't change randomly as the result of a build.

It looks like this was intended in cc115941a27c7a55bb57892044fade17252e5bb0, but protobuf was still free to serialize maps however it saw fit.

