### PR TITLE
Fix #718: Support Amiibos that have never been written to

### DIFF
--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/amiibo/AmiiboTransitFactory.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/amiibo/AmiiboTransitFactory.kt
@@ -31,7 +31,12 @@ import au.id.micolous.metrodroid.util.ImmutableByteArray
 object AmiiboTransitFactory : UltralightCardTransitFactory {
     override fun check(card: UltralightCard) = (card.cardModel == "NTAG215" || card.pages.size == 136) &&
             // Amiibos are always locked and configured in the same way
-            card.readPages(2,3).sliceOffLen(2, 7) == ImmutableByteArray.fromHex("0fe0f110ffeea5") &&
+            card.readPages(2,2).sliceOffLen(2, 6) == ImmutableByteArray.fromHex("0fe0f110ffee") &&
+            (
+                // https://github.com/metrodroid/metrodroid/issues/718
+                card.getPage(0x4).data[0] == 0xa5.toByte() || // used
+                card.getPage(0x4).data.isAllZero() // unused
+            ) &&
             card.getPage(0x16).data[3] == 2.toByte() &&
             card.getPage(0x82).data.byteArrayToInt(0,3) == 0x01000f &&
             card.readPages(0x83,2) == ImmutableByteArray.fromHex("000000045f000000")


### PR DESCRIPTION
According to https://www.3dbrew.org/wiki/Amiibo#Page_layout, page 0x4

* always starts with 0xA5
* remaining bytes are initially all-zero

I read this as "and", but it's probably "and/or": #718 has a dump of a Amiibo that I suspect has never been written to by Nintendo hardware/software.

Before:

```
% ./metrodroid-cli parse ~/dev/cards/amiibo/green-yoshi-nvl-201.json
card UID = <04138f9a844981>
   name = null
   serial = null
```

After:

```
% ./metrodroid-cli parse ~/dev/cards/amiibo/green-yoshi-nvl-201.json
card UID = <04138f9a844981>
   name = Amiibo
   serial = null
   info
      Type: Yarn
      Character: Yoshi [0x3]
      Character variant: 1
      Model number: 65
      Series: Yoshi's Woolly World
```