### PR TITLE
Fix large font layout issues on Android

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -229,6 +229,7 @@ dependencies {
     implementation 'com.github.bmelnychuk:atv:1.2.9'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'com.google.android.material:material:1.0.0'
 
     androidTestUtil "androidx.test:orchestrator:$android_test_version"
     androidTestImplementation "androidx.test:rules:$android_test_version"

--- a/src/main/res/layout/activity_about.xml
+++ b/src/main/res/layout/activity_about.xml
@@ -1,69 +1,86 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
-    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
-    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:layout_height="match_parent"
+    android:fillViewport="true"
     tools:context=".activity.AboutActivity">
 
-    <ImageView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:id="@+id/imageView"
-        android:layout_alignParentTop="true"
-        android:layout_centerHorizontal="true"
-        android:contentDescription="@string/app_logo_description"
-        android:background="@drawable/logo" />
+    <LinearLayout
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin"
+        android:paddingTop="@dimen/activity_vertical_margin"
+        android:paddingBottom="@dimen/activity_vertical_margin"
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textAppearance="?android:attr/textAppearanceMedium"
-        android:id="@+id/lblCopyright"
-        android:text="@string/copyright"
-        android:layout_below="@+id/imageView"
-        android:layout_centerHorizontal="true"
-        android:paddingBottom="12dp"
-        android:gravity="center" />
+        <ImageView
+            android:id="@+id/imageView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:background="@drawable/logo"
+            android:contentDescription="@string/app_logo_description"
+            android:scaleType="centerInside" />
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textAppearance="?android:attr/textAppearanceSmall"
-        android:id="@+id/lblDebugText"
-        android:layout_below="@+id/lblCopyright"
-        android:layout_centerHorizontal="true"
-        android:gravity="center" />
+        <TextView
+            android:id="@+id/lblCopyright"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:paddingBottom="12dp"
+            android:text="@string/copyright"
+            android:textAppearance="?android:attr/textAppearanceMedium" />
 
-    <Button
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/visit_website"
-        android:id="@+id/btnWebsite"
-        android:onClick="onWebsiteClick"
-        android:layout_alignParentBottom="true"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true"
-        style="?attr/ButtonStyle" />
+        <TextView
+            android:id="@+id/lblDebugText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:textAppearance="?android:attr/textAppearanceSmall" />
 
-    <Button
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/license"
-        android:id="@+id/btnLicense"
-        android:layout_alignTop="@+id/btnWebsite"
-        android:layout_alignParentRight="true"
-        android:layout_alignParentEnd="true"
-        style="?attr/ButtonStyle"
-        android:onClick="onLicenseClick" />
+        <Space
+            android:layout_gravity="fill_vertical"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="0dp" />
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textAppearance="?android:attr/textAppearanceSmall"
-        android:text="@string/lawyercats"
-        android:id="@+id/lblLawyers"
-        android:layout_above="@+id/btnWebsite"
-        android:layout_centerHorizontal="true"
-        android:gravity="center" />
-</RelativeLayout>
+        <TextView
+            android:id="@+id/lblLawyers"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:text="@string/lawyercats"
+            android:textAppearance="?android:attr/textAppearanceSmall" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/btnWebsite"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:onClick="onWebsiteClick"
+                android:text="@string/visit_website"
+                style="?attr/ButtonStyle" />
+
+            <Space
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1" />
+
+            <Button
+                android:id="@+id/btnLicense"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:onClick="onLicenseClick"
+                android:text="@string/license"
+                style="?attr/ButtonStyle" />
+        </LinearLayout>
+    </LinearLayout>
+</ScrollView>

--- a/src/main/res/layout/activity_about.xml
+++ b/src/main/res/layout/activity_about.xml
@@ -43,7 +43,8 @@
         android:onClick="onWebsiteClick"
         android:layout_alignParentBottom="true"
         android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true" />
+        android:layout_alignParentStart="true"
+        style="?attr/ButtonStyle" />
 
     <Button
         android:layout_width="wrap_content"
@@ -53,6 +54,7 @@
         android:layout_alignTop="@+id/btnWebsite"
         android:layout_alignParentRight="true"
         android:layout_alignParentEnd="true"
+        style="?attr/ButtonStyle"
         android:onClick="onLicenseClick" />
 
     <TextView

--- a/src/main/res/layout/activity_license.xml
+++ b/src/main/res/layout/activity_license.xml
@@ -1,12 +1,13 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
-    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
-    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:layout_height="match_parent"
     tools:context=".activity.LicenseActivity"
     android:id="@+id/scrollView">
         <TextView
+            android:paddingLeft="@dimen/activity_horizontal_margin"
+            android:paddingRight="@dimen/activity_horizontal_margin"
+            android:paddingTop="@dimen/activity_vertical_margin"
+            android:paddingBottom="@dimen/activity_vertical_margin"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:id="@+id/lblLicenseText" />

--- a/src/main/res/layout/activity_main.xml
+++ b/src/main/res/layout/activity_main.xml
@@ -57,16 +57,17 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="32dp"
             android:layout_gravity="center"
-            android:gravity="center"
-            tools:ignore="ButtonStyle">
-            <!-- This is not a ButtonBar. -->
+            android:gravity="center">
 
             <Button
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
                 android:layout_gravity="center"
+                android:insetLeft="4dp"
+                android:insetRight="4dp"
                 android:layout_weight="1"
                 android:onClick="onSupportedCardsClick"
+                style="?attr/ButtonStyle"
                 android:text="@string/supported_cards" />
 
             <Button
@@ -74,7 +75,10 @@
                 android:layout_height="match_parent"
                 android:layout_gravity="center"
                 android:layout_weight="1"
+                android:insetLeft="4dp"
+                android:insetRight="4dp"
                 android:onClick="onHistoryClick"
+                style="?attr/ButtonStyle"
                 android:text="@string/scanned_cards" />
         </LinearLayout>
     </LinearLayout>

--- a/src/main/res/layout/subscription_item.xml
+++ b/src/main/res/layout/subscription_item.xml
@@ -91,7 +91,7 @@
         <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/name"
             android:layout_width="0dp"
-            android:layout_height="76dp"
+            android:layout_height="wrap_content"
             android:gravity="center"
             android:maxLines="5"
             android:paddingBottom="4dp"

--- a/src/main/res/values/attrs.xml
+++ b/src/main/res/values/attrs.xml
@@ -15,9 +15,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <resources>
-    <attr name="ButtonBarButtonStyle" format="reference" />
-    <attr name="ButtonBarStyle" format="reference" />
-    <attr name="BorderlessButtonStyle" format="reference" />
+    <attr name="ButtonStyle" format="reference" />
     <attr name="MainActivityTheme" format="reference" />
     <attr name="LockImage" format="reference" />
     <attr name="LockImageUnlocked" format="reference" />

--- a/src/main/res/values/themes.xml
+++ b/src/main/res/values/themes.xml
@@ -20,10 +20,10 @@
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="DuplicateDefinition">
     <color name="Metrodroid.Dark.CardIdTextColor">#ffcc44</color>
 
-    <style name="Metrodroid.Dark" parent="@style/Theme.AppCompat">
-        <item name="ButtonBarStyle">@android:style/Holo.ButtonBar.AlertDialog</item>
-        <item name="BorderlessButtonStyle">@android:style/Widget.Holo.Button.Borderless.Small</item>
-        <item name="ButtonBarButtonStyle">@android:style/Widget.Holo.Button.Borderless.Small</item>
+    <style name="Metrodroid.Dark" parent="@style/Theme.MaterialComponents">
+        <item name="colorPrimary">#338855</item>
+        <item name="colorPrimaryDark">#224422</item>
+        <item name="ButtonStyle">@android:style/Widget.Holo.Button.Borderless.Small</item>
         <item name="LockImage">@drawable/locked</item>
         <item name="LockImageUnlocked">@drawable/unlocked</item>
         <item name="MainActivityTheme">@style/Metrodroid.Dark</item>
@@ -34,9 +34,7 @@
     </style>
 
     <style name="Metrodroid.Dark.Dialog" parent="@android:style/Theme.DeviceDefault.Dialog">
-        <item name="ButtonBarStyle">@android:style/Holo.ButtonBar.AlertDialog</item>
-        <item name="BorderlessButtonStyle">@android:style/Widget.Holo.Button.Borderless.Small</item>
-        <item name="ButtonBarButtonStyle">@android:style/Widget.Holo.Button.Borderless.Small</item>
+        <item name="ButtonStyle">@android:style/Widget.Holo.Button.Borderless.Small</item>
         <item name="LockImage">@drawable/locked</item>
         <item name="LockImageUnlocked">@drawable/unlocked</item>
     </style>
@@ -61,10 +59,10 @@
 
     <color name="Metrodroid.Light.CardIdTextColor">#bb5500</color>
 
-    <style name="Metrodroid.Light" parent="@style/Theme.AppCompat.Light">
-        <item name="ButtonBarStyle">@android:style/Holo.Light.ButtonBar.AlertDialog</item>
-        <item name="BorderlessButtonStyle">@android:style/Widget.Holo.Light.Button.Borderless.Small</item>
-        <item name="ButtonBarButtonStyle">@android:style/Widget.Holo.Light.Button.Borderless.Small</item>
+    <style name="Metrodroid.Light" parent="@style/Theme.MaterialComponents.Light">
+        <item name="colorPrimary">#44ff99</item>
+        <item name="colorPrimaryDark">#33bb66</item>
+        <item name="ButtonStyle">@android:style/Widget.Holo.Light.Button.Borderless.Small</item>
         <item name="LockImage">@drawable/locked</item>
         <item name="LockImageUnlocked">@drawable/unlocked</item>
         <item name="MainActivityTheme">@style/Metrodroid.Light</item>
@@ -75,9 +73,7 @@
     </style>
 
     <style name="Metrodroid.Light.Dialog" parent="@android:style/Theme.DeviceDefault.Dialog">
-        <item name="ButtonBarStyle">@android:style/Holo.Light.ButtonBar.AlertDialog</item>
-        <item name="BorderlessButtonStyle">@android:style/Widget.Holo.Light.Button.Borderless.Small</item>
-        <item name="ButtonBarButtonStyle">@android:style/Widget.Holo.Light.Button.Borderless.Small</item>
+        <item name="ButtonStyle">@android:style/Widget.Holo.Light.Button.Borderless.Small</item>
         <item name="LockImage">@drawable/locked</item>
         <item name="LockImageUnlocked">@drawable/unlocked</item>
     </style>
@@ -108,9 +104,7 @@
         <item name="actionBarStyle">@style/FareBot.Theme.ActionBar</item>
         <item name="android:actionBarDivider">@null</item>
         <item name="android:windowContentOverlay">@null</item>
-        <item name="ButtonBarStyle">@android:style/Holo.ButtonBar.AlertDialog</item>
-        <item name="BorderlessButtonStyle">@android:style/Widget.Holo.Light.Button.Borderless.Small</item>
-        <item name="ButtonBarButtonStyle">@android:style/Widget.Holo.Light.Button.Borderless.Small</item>
+        <item name="ButtonStyle">@android:style/Widget.Holo.Light.Button.Borderless.Small</item>
         <item name="LockImage">@drawable/locked</item>
         <item name="LockImageUnlocked">@drawable/unlocked</item>
         <item name="TransportIcons">@array/FareBot.Theme.TransportIcons</item>

--- a/src/main/res/xml/prefs.xml
+++ b/src/main/res/xml/prefs.xml
@@ -4,7 +4,7 @@
   prefs.xml
 
   Copyright 2011 Eric Butler <eric@codebutler.com>
-  Copyright 2016-2019 Michael Farrell <mioolous+git@gmail.com>
+  Copyright 2016-2020 Michael Farrell <mioolous+git@gmail.com>
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -21,19 +21,24 @@
   -->
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:npp="http://micolous.github.io/metrodroid/schemas/number-picker-preference">
-    <PreferenceCategory android:title="@string/general">
+    <PreferenceCategory
+        android:title="@string/general"
+        app:singleLineTitle="false">
         <CheckBoxPreference
             android:key="pref_launch_from_background"
             android:persistent="false"
-            android:title="@string/launch_from_background" />
+            android:title="@string/launch_from_background"
+            app:singleLineTitle="false" />
 
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="pref_convert_timezones"
             android:summaryOff="@string/convert_timezones_summary_off"
             android:summaryOn="@string/convert_timezones_summary_on"
-            android:title="@string/convert_timezones" />
+            android:title="@string/convert_timezones"
+            app:singleLineTitle="false" />
 
         <ListPreference
             android:defaultValue="dark"
@@ -41,27 +46,33 @@
             android:entryValues="@array/theme_values"
             android:key="pref_theme"
             android:summary="@string/pref_theme_desc"
-            android:title="@string/pref_theme" />
+            android:title="@string/pref_theme"
+            app:singleLineTitle="false" />
     </PreferenceCategory>
 
-    <PreferenceCategory android:title="@string/accessibility">
+    <PreferenceCategory
+        android:title="@string/accessibility"
+        app:singleLineTitle="false">
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="pref_localise_places"
             android:summary="@string/localise_places_desc"
-            android:title="@string/localise_places" />
+            android:title="@string/localise_places"
+            app:singleLineTitle="false" />
 
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="pref_key_speak_balance"
             android:summary="@string/speak_balance_summary"
-            android:title="@string/speak_balance" />
+            android:title="@string/speak_balance"
+            app:singleLineTitle="false" />
 
         <au.id.micolous.metrodroid.ui.AlertDialogPreference
             android:dialogMessage="@string/localise_places_longdesc"
             android:dialogTitle="@string/localise_places_longdesc_title"
             android:key="pref_localise_places_help"
-            android:title="@string/localise_places_longdesc_button" />
+            android:title="@string/localise_places_longdesc_button"
+            app:singleLineTitle="false" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/maps">
@@ -69,16 +80,19 @@
             android:defaultValue="@string/default_map_tile_url"
             android:key="pref_map_tile_url"
             android:summary="@string/map_tiles_url_summary"
-            android:title="@string/map_tiles_url" />
+            android:title="@string/map_tiles_url"
+            app:singleLineTitle="false" />
         <EditTextPreference
             android:defaultValue="@string/default_map_tile_subdomains"
             android:key="pref_map_tile_subdomains"
             android:summary="@string/map_tiles_subdomains_summary"
-            android:title="@string/map_tiles_subdomains" />
+            android:title="@string/map_tiles_subdomains"
+            app:singleLineTitle="false" />
         <PreferenceScreen
             android:key="pref_map_tilelayer_docs"
             android:summary="@string/map_tiles_help_summary"
-            android:title="@string/map_tiles_help">
+            android:title="@string/map_tiles_help"
+            app:singleLineTitle="false">
             <intent
                 android:action="android.intent.action.VIEW"
                 android:data="http://leafletjs.com/reference-1.3.4.html#tilelayer" />
@@ -89,73 +103,93 @@
         <PreferenceScreen
             android:key="pref_nfc_screen"
             android:summary="@string/nfc_options_desc"
-            android:title="@string/nfc">
-            <PreferenceCategory android:title="@string/hardware">
+            android:title="@string/nfc"
+            app:singleLineTitle="false">
+            <PreferenceCategory
+                android:title="@string/hardware"
+                app:singleLineTitle="false">
                 <au.id.micolous.metrodroid.ui.NfcSettingsPreference
                     android:key="pref_android_nfc"
-                    android:title="@string/android_nfc_settings" />
+                    android:title="@string/android_nfc_settings"
+                    app:singleLineTitle="false" />
             </PreferenceCategory>
 
-            <PreferenceCategory android:title="@string/mifare_classic">
+            <PreferenceCategory
+                android:title="@string/mifare_classic"
+                app:singleLineTitle="false">
                 <ListPreference
                     android:defaultValue="null"
                     android:entries="@array/mfc_fallbacks"
                     android:entryValues="@array/mfc_fallback_values"
                     android:key="pref_mfc_fallback"
                     android:summary="@string/mfc_fallback_desc"
-                    android:title="@string/mfc_fallback" />
+                    android:title="@string/mfc_fallback"
+                    app:singleLineTitle="false" />
 
                 <au.id.micolous.metrodroid.ui.NumberPickerPreference
                     android:defaultValue="5"
                     android:key="pref_mfc_authretry"
                     android:summary="@string/auth_retries_summary"
                     android:title="@string/auth_retries"
+                    app:singleLineTitle="false"
                     npp:maxValue="20"
                     npp:minValue="1" />
             </PreferenceCategory>
 
-            <PreferenceCategory android:title="@string/mifare_desfire">
+            <PreferenceCategory
+                android:title="@string/mifare_desfire"
+                app:singleLineTitle="false">
                 <CheckBoxPreference
                     android:defaultValue="false"
                     android:key="pref_retrieve_leap_keys"
                     android:summary="@string/leap_retrieve_keys_longdesc"
-                    android:title="@string/leap_retrieve_keys" />
+                    android:title="@string/leap_retrieve_keys"
+                    app:singleLineTitle="false" />
             </PreferenceCategory>
         </PreferenceScreen>
 
         <PreferenceScreen
             android:key="pref_dev_screen"
             android:summary="@string/developer_options_desc"
-            android:title="@string/developer_options">
-            <PreferenceCategory android:title="@string/supported_cards">
+            android:title="@string/developer_options"
+            app:singleLineTitle="false">
+            <PreferenceCategory
+                android:title="@string/supported_cards"
+                app:singleLineTitle="false">
                 <CheckBoxPreference
                     android:defaultValue="false"
                     android:key="pref_hide_unsupported_ribbon"
                     android:summaryOff="@string/pref_hide_unsupported_ribbon_desc_off"
                     android:summaryOn="@string/pref_hide_unsupported_ribbon_desc_on"
-                    android:title="@string/pref_hide_unsupported_ribbon" />
+                    android:title="@string/pref_hide_unsupported_ribbon"
+                    app:singleLineTitle="false" />
 
             </PreferenceCategory>
 
-            <PreferenceCategory android:title="@string/station_database">
+            <PreferenceCategory
+                android:title="@string/station_database"
+                app:singleLineTitle="false">
                 <CheckBoxPreference
                     android:defaultValue="false"
                     android:key="pref_show_local_and_english"
                     android:summary="@string/pref_show_local_and_english_desc"
-                    android:title="@string/pref_show_local_and_english_title" />
+                    android:title="@string/pref_show_local_and_english_title"
+                    app:singleLineTitle="false" />
 
                 <CheckBoxPreference
                     android:defaultValue="false"
                     android:key="pref_show_raw_ids"
                     android:summaryOff="@string/pref_show_raw_station_ids_desc_off"
                     android:summaryOn="@string/pref_show_raw_station_ids_desc_on"
-                    android:title="@string/pref_show_raw_station_ids" />
+                    android:title="@string/pref_show_raw_station_ids"
+                    app:singleLineTitle="false" />
 
                 <CheckBoxPreference
                     android:defaultValue="false"
                     android:key="pref_debug_spans"
                     android:summary="@string/show_debug_spans_desc"
-                    android:title="@string/show_debug_spans" />
+                    android:title="@string/show_debug_spans"
+                    app:singleLineTitle="false" />
 
                 <ListPreference
                     android:defaultValue="0"
@@ -163,49 +197,61 @@
                     android:entryValues="@array/raw_levels_values"
                     android:key="pref_raw_level"
                     android:summary="@string/raw_level_desc"
-                    android:title="@string/raw_level" />
+                    android:title="@string/raw_level"
+                    app:singleLineTitle="false" />
 
                 <ListPreference
                     android:key="pref_lang_override"
                     android:summary="@string/lang_override_desc"
-                    android:title="@string/lang_override" />
+                    android:title="@string/lang_override"
+                    app:singleLineTitle="false" />
             </PreferenceCategory>
 
-            <PreferenceCategory android:title="@string/obfuscation_title">
+            <PreferenceCategory
+                android:title="@string/obfuscation_title"
+                app:singleLineTitle="false">
                 <CheckBoxPreference
                     android:defaultValue="false"
                     android:key="pref_hide_card_numbers"
                     android:summary="@string/obfuscation_card_numbers_desc"
-                    android:title="@string/obfuscation_card_numbers" />
+                    android:title="@string/obfuscation_card_numbers"
+                    app:singleLineTitle="false" />
                 <CheckBoxPreference
                     android:defaultValue="false"
                     android:key="pref_obfuscate_balance"
                     android:summary="@string/obfuscation_balance_desc"
-                    android:title="@string/obfuscation_balance" />
+                    android:title="@string/obfuscation_balance"
+                    app:singleLineTitle="false" />
                 <CheckBoxPreference
                     android:defaultValue="false"
                     android:key="pref_obfuscate_trip_dates"
                     android:summary="@string/obfuscation_dates_desc"
-                    android:title="@string/obfuscation_dates" />
+                    android:title="@string/obfuscation_dates"
+                    app:singleLineTitle="false" />
                 <CheckBoxPreference
                     android:defaultValue="false"
                     android:key="pref_obfuscate_trip_times"
                     android:summary="@string/obfuscation_times_desc"
-                    android:title="@string/obfuscation_times" />
+                    android:title="@string/obfuscation_times"
+                    app:singleLineTitle="false" />
                 <CheckBoxPreference
                     android:defaultValue="false"
                     android:key="pref_obfuscate_trip_fares"
                     android:summary="@string/obfuscation_fares_desc"
-                    android:title="@string/obfuscation_fares" />
+                    android:title="@string/obfuscation_fares"
+                    app:singleLineTitle="false" />
             </PreferenceCategory>
 
-            <PreferenceCategory android:title="@string/card_media_felica">
+            <PreferenceCategory
+                android:title="@string/card_media_felica"
+                app:singleLineTitle="false">
                 <CheckBoxPreference
                     android:defaultValue="false"
                     android:key="pref_felica_only_first"
                     android:summaryOff="@string/felica_first_system_pref_summary_off"
                     android:summaryOn="@string/felica_first_system_pref_summary_on"
-                    android:title="@string/felica_first_system_pref" />
+                    android:title="@string/felica_first_system_pref"
+                    app:singleLineTitle="false" />
             </PreferenceCategory>
         </PreferenceScreen>
     </PreferenceCategory>

--- a/src/main/res/xml/prefs.xml
+++ b/src/main/res/xml/prefs.xml
@@ -20,77 +20,76 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<PreferenceScreen
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:npp="http://micolous.github.io/metrodroid/schemas/number-picker-preference">
-    <PreferenceCategory
-        android:title="@string/general">
+    <PreferenceCategory android:title="@string/general">
         <CheckBoxPreference
-            android:title="@string/launch_from_background"
+            android:key="pref_launch_from_background"
             android:persistent="false"
-            android:key="pref_launch_from_background"/>
+            android:title="@string/launch_from_background" />
 
         <CheckBoxPreference
-            android:title="@string/convert_timezones"
+            android:defaultValue="false"
+            android:key="pref_convert_timezones"
             android:summaryOff="@string/convert_timezones_summary_off"
             android:summaryOn="@string/convert_timezones_summary_on"
-            android:key="pref_convert_timezones"
-            android:defaultValue="false"/>
+            android:title="@string/convert_timezones" />
 
         <ListPreference
-            android:key="pref_theme"
-            android:title="@string/pref_theme"
-            android:summary="@string/pref_theme_desc"
             android:defaultValue="dark"
             android:entries="@array/themes"
-            android:entryValues="@array/theme_values" />
+            android:entryValues="@array/theme_values"
+            android:key="pref_theme"
+            android:summary="@string/pref_theme_desc"
+            android:title="@string/pref_theme" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/accessibility">
         <CheckBoxPreference
-            android:title="@string/localise_places"
-            android:summary="@string/localise_places_desc"
+            android:defaultValue="false"
             android:key="pref_localise_places"
-            android:defaultValue="false" />
-
-        <au.id.micolous.metrodroid.ui.AlertDialogPreference
-            android:title="@string/localise_places_longdesc_button"
-            android:dialogMessage="@string/localise_places_longdesc"
-            android:dialogTitle="@string/localise_places_longdesc_title"
-            android:key="pref_localise_places_help" />
+            android:summary="@string/localise_places_desc"
+            android:title="@string/localise_places" />
 
         <CheckBoxPreference
-            android:title="@string/speak_balance"
-            android:summary="@string/speak_balance_summary"
+            android:defaultValue="false"
             android:key="pref_key_speak_balance"
-            android:defaultValue="false" />
+            android:summary="@string/speak_balance_summary"
+            android:title="@string/speak_balance" />
+
+        <au.id.micolous.metrodroid.ui.AlertDialogPreference
+            android:dialogMessage="@string/localise_places_longdesc"
+            android:dialogTitle="@string/localise_places_longdesc_title"
+            android:key="pref_localise_places_help"
+            android:title="@string/localise_places_longdesc_button" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/maps">
         <EditTextPreference
-            android:title="@string/map_tiles_url"
-            android:summary="@string/map_tiles_url_summary"
+            android:defaultValue="@string/default_map_tile_url"
             android:key="pref_map_tile_url"
-            android:defaultValue="@string/default_map_tile_url"/>
+            android:summary="@string/map_tiles_url_summary"
+            android:title="@string/map_tiles_url" />
         <EditTextPreference
-            android:title="@string/map_tiles_subdomains"
-            android:summary="@string/map_tiles_subdomains_summary"
+            android:defaultValue="@string/default_map_tile_subdomains"
             android:key="pref_map_tile_subdomains"
-            android:defaultValue="@string/default_map_tile_subdomains"/>
+            android:summary="@string/map_tiles_subdomains_summary"
+            android:title="@string/map_tiles_subdomains" />
         <PreferenceScreen
             android:key="pref_map_tilelayer_docs"
-            android:title="@string/map_tiles_help"
-            android:summary="@string/map_tiles_help_summary">
-            <intent android:action="android.intent.action.VIEW"
+            android:summary="@string/map_tiles_help_summary"
+            android:title="@string/map_tiles_help">
+            <intent
+                android:action="android.intent.action.VIEW"
                 android:data="http://leafletjs.com/reference-1.3.4.html#tilelayer" />
         </PreferenceScreen>
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/advanced_options">
         <PreferenceScreen
-            android:title="@string/nfc"
             android:key="pref_nfc_screen"
-            android:summary="@string/nfc_options_desc">
+            android:summary="@string/nfc_options_desc"
+            android:title="@string/nfc">
             <PreferenceCategory android:title="@string/hardware">
                 <au.id.micolous.metrodroid.ui.NfcSettingsPreference
                     android:key="pref_android_nfc"
@@ -98,119 +97,116 @@
             </PreferenceCategory>
 
             <PreferenceCategory android:title="@string/mifare_classic">
-                <au.id.micolous.metrodroid.ui.NumberPickerPreference
-                    android:title="@string/auth_retries"
-                    android:summary="@string/auth_retries_summary"
-                    android:defaultValue="5"
-                    android:key="pref_mfc_authretry"
-                    npp:minValue="1"
-                    npp:maxValue="20" />
-
                 <ListPreference
-                    android:key="pref_mfc_fallback"
-                    android:title="@string/mfc_fallback"
-                    android:summary="@string/mfc_fallback_desc"
                     android:defaultValue="null"
                     android:entries="@array/mfc_fallbacks"
                     android:entryValues="@array/mfc_fallback_values"
-                    />
+                    android:key="pref_mfc_fallback"
+                    android:summary="@string/mfc_fallback_desc"
+                    android:title="@string/mfc_fallback" />
+
+                <au.id.micolous.metrodroid.ui.NumberPickerPreference
+                    android:defaultValue="5"
+                    android:key="pref_mfc_authretry"
+                    android:summary="@string/auth_retries_summary"
+                    android:title="@string/auth_retries"
+                    npp:maxValue="20"
+                    npp:minValue="1" />
             </PreferenceCategory>
-	    
-	        <PreferenceCategory android:title="@string/mifare_desfire">
+
+            <PreferenceCategory android:title="@string/mifare_desfire">
                 <CheckBoxPreference
-                    android:title="@string/leap_retrieve_keys"
-                    android:summary="@string/leap_retrieve_keys_longdesc"
+                    android:defaultValue="false"
                     android:key="pref_retrieve_leap_keys"
-                    android:defaultValue="false" />
-	        </PreferenceCategory>
-    </PreferenceScreen>
+                    android:summary="@string/leap_retrieve_keys_longdesc"
+                    android:title="@string/leap_retrieve_keys" />
+            </PreferenceCategory>
+        </PreferenceScreen>
 
-    <PreferenceScreen
-        android:title="@string/developer_options"
-        android:key="pref_dev_screen"
-        android:summary="@string/developer_options_desc">
-        <PreferenceCategory android:title="@string/supported_cards">
-            <CheckBoxPreference
-                android:title="@string/pref_hide_unsupported_ribbon"
-                android:summaryOff="@string/pref_hide_unsupported_ribbon_desc_off"
-                android:summaryOn="@string/pref_hide_unsupported_ribbon_desc_on"
-                android:key="pref_hide_unsupported_ribbon"
-                android:defaultValue="false" />
+        <PreferenceScreen
+            android:key="pref_dev_screen"
+            android:summary="@string/developer_options_desc"
+            android:title="@string/developer_options">
+            <PreferenceCategory android:title="@string/supported_cards">
+                <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:key="pref_hide_unsupported_ribbon"
+                    android:summaryOff="@string/pref_hide_unsupported_ribbon_desc_off"
+                    android:summaryOn="@string/pref_hide_unsupported_ribbon_desc_on"
+                    android:title="@string/pref_hide_unsupported_ribbon" />
 
-        </PreferenceCategory>
+            </PreferenceCategory>
 
-        <PreferenceCategory android:title="@string/station_database">
-            <CheckBoxPreference
-                android:title="@string/pref_show_local_and_english_title"
-                android:summary="@string/pref_show_local_and_english_desc"
-                android:key="pref_show_local_and_english"
-                android:defaultValue="false" />
+            <PreferenceCategory android:title="@string/station_database">
+                <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:key="pref_show_local_and_english"
+                    android:summary="@string/pref_show_local_and_english_desc"
+                    android:title="@string/pref_show_local_and_english_title" />
 
-            <CheckBoxPreference
-                android:title="@string/pref_show_raw_station_ids"
-                android:summaryOn="@string/pref_show_raw_station_ids_desc_on"
-                android:summaryOff="@string/pref_show_raw_station_ids_desc_off"
-                android:key="pref_show_raw_ids"
-                android:defaultValue="false" />
+                <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:key="pref_show_raw_ids"
+                    android:summaryOff="@string/pref_show_raw_station_ids_desc_off"
+                    android:summaryOn="@string/pref_show_raw_station_ids_desc_on"
+                    android:title="@string/pref_show_raw_station_ids" />
 
-            <CheckBoxPreference
-                    android:title="@string/show_debug_spans"
-                    android:summary="@string/show_debug_spans_desc"
+                <CheckBoxPreference
+                    android:defaultValue="false"
                     android:key="pref_debug_spans"
-                    android:defaultValue="false" />
+                    android:summary="@string/show_debug_spans_desc"
+                    android:title="@string/show_debug_spans" />
 
-            <ListPreference
-                    android:key="pref_raw_level"
-                    android:title="@string/raw_level"
-                    android:summary="@string/raw_level_desc"
+                <ListPreference
                     android:defaultValue="0"
                     android:entries="@array/raw_levels"
                     android:entryValues="@array/raw_levels_values"
-            />
+                    android:key="pref_raw_level"
+                    android:summary="@string/raw_level_desc"
+                    android:title="@string/raw_level" />
 
-            <ListPreference
+                <ListPreference
                     android:key="pref_lang_override"
-                    android:title="@string/lang_override"
                     android:summary="@string/lang_override_desc"
-            />
-        </PreferenceCategory>
+                    android:title="@string/lang_override" />
+            </PreferenceCategory>
 
-        <PreferenceCategory android:title="@string/obfuscation_title">
-            <CheckBoxPreference
-                android:title="@string/obfuscation_card_numbers"
-                android:summary="@string/obfuscation_card_numbers_desc"
-                android:key="pref_hide_card_numbers"
-                android:defaultValue="false" />
-            <CheckBoxPreference
-                android:title="@string/obfuscation_balance"
-                android:summary="@string/obfuscation_balance_desc"
-                android:key="pref_obfuscate_balance"
-                android:defaultValue="false" />
-            <CheckBoxPreference
-                android:title="@string/obfuscation_dates"
-                android:summary="@string/obfuscation_dates_desc"
-                android:key="pref_obfuscate_trip_dates"
-                android:defaultValue="false" />
-            <CheckBoxPreference
-                android:title="@string/obfuscation_times"
-                android:summary="@string/obfuscation_times_desc"
-                android:key="pref_obfuscate_trip_times"
-                android:defaultValue="false" />
-            <CheckBoxPreference
-                android:title="@string/obfuscation_fares"
-                android:summary="@string/obfuscation_fares_desc"
-                android:key="pref_obfuscate_trip_fares"
-                android:defaultValue="false" />
-        </PreferenceCategory>
+            <PreferenceCategory android:title="@string/obfuscation_title">
+                <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:key="pref_hide_card_numbers"
+                    android:summary="@string/obfuscation_card_numbers_desc"
+                    android:title="@string/obfuscation_card_numbers" />
+                <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:key="pref_obfuscate_balance"
+                    android:summary="@string/obfuscation_balance_desc"
+                    android:title="@string/obfuscation_balance" />
+                <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:key="pref_obfuscate_trip_dates"
+                    android:summary="@string/obfuscation_dates_desc"
+                    android:title="@string/obfuscation_dates" />
+                <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:key="pref_obfuscate_trip_times"
+                    android:summary="@string/obfuscation_times_desc"
+                    android:title="@string/obfuscation_times" />
+                <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:key="pref_obfuscate_trip_fares"
+                    android:summary="@string/obfuscation_fares_desc"
+                    android:title="@string/obfuscation_fares" />
+            </PreferenceCategory>
 
-        <PreferenceCategory android:title="@string/card_media_felica">
-            <CheckBoxPreference
-                android:title="@string/felica_first_system_pref"
-                android:summaryOff="@string/felica_first_system_pref_summary_off"
-                android:summaryOn="@string/felica_first_system_pref_summary_on"
-                android:key="pref_felica_only_first"
-                android:defaultValue="false" />
-        </PreferenceCategory>
-    </PreferenceScreen>
+            <PreferenceCategory android:title="@string/card_media_felica">
+                <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:key="pref_felica_only_first"
+                    android:summaryOff="@string/felica_first_system_pref_summary_off"
+                    android:summaryOn="@string/felica_first_system_pref_summary_on"
+                    android:title="@string/felica_first_system_pref" />
+            </PreferenceCategory>
+        </PreferenceScreen>
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
This fixes issues when Android is set to use the largest font and display sizes (fixes #744):

* 203a5f7289232a51dd39d01788320d63e08db990: always use multi-line labels for titles of preferences (which is also a problem for German at default font size)
* 482b0cb907bb5f92f027a03109d997709a0ed15e: wrap the About screen in a `ScrollView`
* 3bac09cd346e88e522b8b91ff7dd90c14b0dc268: move License screen's padding from the `ScrollView` to the `TextView`, so it has a larger viewport
* 6d35f303aa1fdfd74bca2acfc6789dd07f843c56: show full subscription names at large font sizes

Screenshots here: https://github.com/metrodroid/metrodroid/issues/744#issuecomment-752826115

Rebasing on #662 (Material Design).