### PR TITLE
Québec OPUS card fixes

### DIFF
--- a/data/opus/rtc.xml
+++ b/data/opus/rtc.xml
@@ -3,6 +3,7 @@
   rtc.xml
 
   Copyright 2018 Etienne Dubeau
+  Copyright 2020 Aleksei Trubnikov
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -107,7 +108,7 @@
     <bus id="" logo="express" name="EXPRESS 239" />
     <bus id="62" logo="express" name="EXPRESS 250" />
     <bus id="63" logo="express" name="EXPRESS 251" />
-    <bus id="" logo="express" name="EXPRESS 253" />
+    <bus id="322" logo="express" name="EXPRESS 253" />
     <bus id="64" logo="express" name="EXPRESS 254" />
     <bus id="65" logo="express" name="EXPRESS 255" />
     <bus id="67" logo="express" name="EXPRESS 272" />
@@ -139,7 +140,7 @@
     <bus id="" logo="express" name="EXPRESS 374" />
     <bus id="" logo="express" name="EXPRESS 377" />
     <bus id="" logo="express" name="EXPRESS 380" />
-    <bus id="" logo="express" name="EXPRESS 381" />
+    <bus id="150" logo="express" name="EXPRESS 381" />
     <bus id="90" logo="express" name="EXPRESS 382" />
     <bus id="" logo="express" name="EXPRESS 384" />
     <bus id="94" logo="express" name="EXPRESS 391" />

--- a/data/opus/rtl.xml
+++ b/data/opus/rtl.xml
@@ -3,6 +3,7 @@
   rtl.xml
 
   Copyright 2018 Etienne Dubeau
+  Copyright 2020 Aleksei Trubnikov
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -37,7 +38,7 @@
     <bus id="20" logo="" name="21" />
     <bus id="" logo="" name="22" />
     <bus id="" logo="" name="23" />
-    <bus id="" logo="" name="25" />
+    <bus id="295" logo="" name="25" />
     <bus id="" logo="" name="28" />
     <bus id="23" logo="" name="29" />
     <bus id="" logo="" name="30" />
@@ -124,7 +125,7 @@
     <bus id="" logo="" name="539" />
     <bus id="" logo="" name="540" />
     <bus id="" logo="" name="542" />
-    <bus id="" logo="" name="544" />
+    <bus id="368" logo="" name="544" />
     <bus id="" logo="" name="546" />
     <bus id="" logo="" name="547" />
     <bus id="" logo="" name="549" />

--- a/data/opus/stl.xml
+++ b/data/opus/stl.xml
@@ -3,6 +3,7 @@
   stl.xml
 
   Copyright 2018 Etienne Dubeau
+  Copyright 2020 Aleksei Trubnikov
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -18,10 +19,10 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <stl>
-    <bus id="146" logo="" name="2" />
+    <bus id="89" logo="" name="2" />
     <bus id="" logo="" name="12" />
     <bus id="" logo="" name="17" />
-    <bus id="" logo="" name="20" />
+    <bus id="5" logo="" name="20" />
     <bus id="" logo="" name="22" />
     <bus id="" logo="" name="24" />
     <bus id="7" logo="" name="26" />

--- a/data/opus/stm.xml
+++ b/data/opus/stm.xml
@@ -3,6 +3,7 @@
   stm.xml
 
   Copyright 2018 Etienne Dubeau
+  Copyright 2020 Aleksei Trubnikov
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -42,7 +43,7 @@
     <bus id="" logo="stm_local" name="29" />
     <bus id="" logo="stm_local" name="30" />
     <bus id="" logo="stm_local" name="31" />
-    <bus id="" logo="stm_local" name="32" />
+    <bus id="22" logo="stm_local" name="32" />
     <bus id="23" logo="stm_local" name="33" />
     <bus id="24" logo="stm_local" name="34" />
     <bus id="" logo="stm_local" name="36" />
@@ -65,7 +66,7 @@
     <bus id="" logo="stm_local" name="56" />
     <bus id="" logo="stm_local" name="57" />
     <bus id="" logo="stm_local" name="58" />
-    <bus id="" logo="stm_local" name="61" />
+    <bus id="44" logo="stm_local" name="61" />
     <bus id="" logo="stm_local" name="63" />
     <bus id="46" logo="stm_local" name="64" />
     <bus id="" logo="stm_local" name="66" />
@@ -157,10 +158,10 @@
     <bus id="" logo="stm_local" name="202" />
     <bus id="" logo="stm_local" name="203" />
     <bus id="" logo="stm_local" name="204" />
-    <bus id="" logo="stm_local" name="205" />
+    <bus id="145" logo="stm_local" name="205" />
     <bus id="" logo="stm_local" name="206" />
     <bus id="147" logo="stm_local" name="207" />
-    <bus id="" logo="stm_local" name="208" />
+    <bus id="148" logo="stm_local" name="208" />
     <bus id="149" logo="stm_local" name="209" />
     <bus id="151" logo="stm_local" name="211" />
     <bus id="" logo="stm_local" name="212" />
@@ -213,21 +214,24 @@
     <bus id="" logo="stm_express" name="439" />
     <bus id="" logo="stm_express" name="440" />
     <bus id="" logo="stm_express" name="444" />
+    <bus id="" logo="stm_express" name="445" />
     <bus id="" logo="stm_express" name="448" />
     <bus id="" logo="stm_express" name="449" />
     <bus id="" logo="stm_express" name="460" />
+    <bus id="" logo="stm_express" name="465" />
     <bus id="211" logo="stm_express" name="467" />
     <bus id="" logo="stm_express" name="468" />
     <bus id="" logo="stm_express" name="469" />
     <bus id="169" logo="stm_express" name="470" />
     <bus id="" logo="stm_express" name="475" />
+    <bus id="" logo="stm_express" name="480" />
     <bus id="" logo="stm_express" name="485" />
     <bus id="" logo="stm_express" name="486" />
-    <bus id="" logo="stm_express" name="487" />
+    <bus id="253" logo="stm_express" name="487" />
     <bus id="" logo="stm_express" name="491" />
     <bus id="255" logo="stm_express" name="495" />
     <bus id="256" logo="stm_express" name="496" />
-    <bus id="" logo="stm_shuttle" name="715" />
+    <bus id="257" logo="stm_shuttle" name="715" />
     <bus id="219" logo="stm_shuttle" name="747" />
     <bus id="" logo="stm_shuttle" name="777" />
     <bus id="" logo="stm_local" name="252" />

--- a/extra/mdst/xml2pb-opus.py
+++ b/extra/mdst/xml2pb-opus.py
@@ -56,10 +56,7 @@ for operator in root.iter('operator'):
   operator_pb = stations_pb2.Operator()
   operator_pb.name.local = operator.attrib['name']
   operator_pb.name.english = operator.attrib['name']
-  if operator.attrib['file'] == 'stm':
-    operator_pb.default_transport = stations_pb2.TRAIN
-  else:
-    operator_pb.default_transport = stations_pb2.BUS
+  operator_pb.default_transport = stations_pb2.BUS
   operators[operator_id] = operator_pb
   operator_xml_tree = ET.parse(os.path.join(DB_PATH, operator.attrib['file'] + '.xml'))
   operator_xml_root = operator_xml_tree.getroot()
@@ -73,6 +70,8 @@ for operator in root.iter('operator'):
       continue
     if line_name.startswith('METRO '):
       line_pb.transport = stations_pb2.METRO
+    if line_name.startswith('TRAIN '):
+      line_pb.transport = stations_pb2.TRAIN
 
     lines[(operator_id << 16)|int(line_id)] = line_pb
 

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/opus/OpusLookup.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/opus/OpusLookup.kt
@@ -50,6 +50,7 @@ object OpusLookup : En1545LookupSTR(OPUS_STR) {
     override val subscriptionMap: Map<Int, StringResource> = mapOf(
             0xb1 to R.string.monthly_subscription,
             0xb2 to R.string.weekly_subscription,
+            0xc9 to R.string.weekly_subscription,
             0x1c7 to R.string.single_trips
     )
 }


### PR DESCRIPTION
**Edit:** Forgot to mention that all ticket types below are STM ones. I don't know if other agencies have different codes.

Namely:

* Correct transport modes. STM run buses and metros, not buses and trains. Commuter rail lines will now be handled as trains instead.
* Ticket type 201 is also weekly subscription.
* Updated the XML files. Those are pulled from https://github.com/tral/LecteurOPUS which is the continuing fork of the original repository. Author is credited. cc. @tral 

Things that I have not included in the PR but you can consider:

* Ticket type 2060 is 10-trip.
* Ticket type 923 is 2-trip.
* Ticket type 1195 is *OPUS à l'essai*. Various transport agencies give away to drivers OPUS cards loaded with 10-trip fares (with shortened validity, which the app correctly interprets). This happened a few times before back in 2016/2017. 
* 2060 and 923 seem to duplicate in cases where only 1 ticket of the type exists (same purchasing time).

Ticket types are confirmed on several OPUS cards, including standard ones and reduced-fare ones.