### PR TITLE
Use getColumnIndexOrThrow instead of getColumnIndex

### DIFF
--- a/src/main/java/au/id/micolous/metrodroid/activity/CardInfoActivity.kt
+++ b/src/main/java/au/id/micolous/metrodroid/activity/CardInfoActivity.kt
@@ -107,7 +107,7 @@ class CardInfoActivity : MetrodroidActivity() {
                     startManagingCursor(cursor)
                     cursor!!.moveToFirst()
 
-                    val data = cursor.getString(cursor.getColumnIndex(CardsTableColumns.DATA))
+                    val data = cursor.getString(cursor.getColumnIndexOrThrow(CardsTableColumns.DATA))
 
                     mCard = XmlOrJsonCardFormat.parseString(data)
                     mTransitData = mCard!!.parseTransitData()

--- a/src/main/java/au/id/micolous/metrodroid/fragment/CardsFragment.kt
+++ b/src/main/java/au/id/micolous/metrodroid/fragment/CardsFragment.kt
@@ -105,9 +105,9 @@ class CardsFragment : ExpandableListFragment(), SearchView.OnQueryTextListener {
             cursor.moveToPosition(-1)
             while (cursor.moveToNext()) {
                 val type = cursor.getInt(cursor
-                        .getColumnIndex(CardsTableColumns.TYPE))
+                        .getColumnIndexOrThrow(CardsTableColumns.TYPE))
                 val serial = cursor.getString(cursor
-                        .getColumnIndex(CardsTableColumns.TAG_SERIAL))
+                        .getColumnIndexOrThrow(CardsTableColumns.TAG_SERIAL))
                 val id = CardId(type, serial)
                 if (!scans.containsKey(id)) {
                     scans[id] = ArrayList()
@@ -127,11 +127,11 @@ class CardsFragment : ExpandableListFragment(), SearchView.OnQueryTextListener {
     }
 
     private class Scan(cursor: Cursor) {
-        val mScannedAt: Long = cursor.getLong(cursor.getColumnIndex(CardsTableColumns.SCANNED_AT))
-        val mLabel: String? = cursor.getString(cursor.getColumnIndex(CardsTableColumns.LABEL))
-        val mType: Int = cursor.getInt(cursor.getColumnIndex(CardsTableColumns.TYPE))
-        val mSerial: String = cursor.getString(cursor.getColumnIndex(CardsTableColumns.TAG_SERIAL))
-        val mData: String = cursor.getString(cursor.getColumnIndex(CardsTableColumns.DATA))
+        val mScannedAt: Long = cursor.getLong(cursor.getColumnIndexOrThrow(CardsTableColumns.SCANNED_AT))
+        val mLabel: String? = cursor.getString(cursor.getColumnIndexOrThrow(CardsTableColumns.LABEL))
+        val mType: Int = cursor.getInt(cursor.getColumnIndexOrThrow(CardsTableColumns.TYPE))
+        val mSerial: String = cursor.getString(cursor.getColumnIndexOrThrow(CardsTableColumns.TAG_SERIAL))
+        val mData: String = cursor.getString(cursor.getColumnIndexOrThrow(CardsTableColumns.DATA))
         val mTransitIdentity: TransitIdentity? by lazy {
             try {
                 XmlOrJsonCardFormat.parseString(mData)?.parseTransitIdentity()
@@ -140,7 +140,7 @@ class CardsFragment : ExpandableListFragment(), SearchView.OnQueryTextListener {
                 TransitIdentity(error, null)
             }
         }
-        val mId: Int = cursor.getInt(cursor.getColumnIndex(CardsTableColumns._ID))
+        val mId: Int = cursor.getInt(cursor.getColumnIndexOrThrow(CardsTableColumns._ID))
 
         fun matches(query: String): Boolean {
             val ti = mTransitIdentity

--- a/src/main/java/au/id/micolous/metrodroid/fragment/KeysFragment.kt
+++ b/src/main/java/au/id/micolous/metrodroid/fragment/KeysFragment.kt
@@ -185,7 +185,7 @@ class KeysFragment : ListFragment(), AdapterView.OnItemLongClickListener {
     override fun onItemLongClick(parent: AdapterView<*>, view: View, position: Int, id: Long): Boolean {
         val cursor = listAdapter?.getItem(position) as Cursor
 
-        mActionKeyId = cursor.getInt(cursor.getColumnIndex(KeysTableColumns._ID))
+        mActionKeyId = cursor.getInt(cursor.getColumnIndexOrThrow(KeysTableColumns._ID))
         mActionMode = requireActivity().startActionMode(mActionModeCallback)
 
         return true
@@ -270,15 +270,15 @@ class KeysFragment : ListFragment(), AdapterView.OnItemLongClickListener {
     private class KeysAdapter(activity: Activity) : ResourceCursorAdapter(activity, android.R.layout.simple_list_item_2, null, false) {
 
         override fun bindView(view: View, context: Context, cursor: Cursor) {
-            @NonNls val id = cursor.getString(cursor.getColumnIndex(KeysTableColumns.CARD_ID))
-            val type = cursor.getString(cursor.getColumnIndex(KeysTableColumns.CARD_TYPE))
+            @NonNls val id = cursor.getString(cursor.getColumnIndexOrThrow(KeysTableColumns.CARD_ID))
+            val type = cursor.getString(cursor.getColumnIndexOrThrow(KeysTableColumns.CARD_TYPE))
 
             val textView1 = view.findViewById<TextView>(android.R.id.text1)
             val textView2 = view.findViewById<TextView>(android.R.id.text2)
 
             when (type) {
                 CardKeys.TYPE_MFC_STATIC -> {
-                    val keyData = cursor.getString(cursor.getColumnIndex(KeysTableColumns.KEY_DATA))
+                    val keyData = cursor.getString(cursor.getColumnIndexOrThrow(KeysTableColumns.KEY_DATA))
                     var desc: String? = null
                     var fileType: String? = null
                     try {
@@ -303,7 +303,7 @@ class KeysFragment : ListFragment(), AdapterView.OnItemLongClickListener {
                     }
                 }
                 CardKeys.TYPE_MFC -> {
-                    val keyData = cursor.getString(cursor.getColumnIndex(KeysTableColumns.KEY_DATA))
+                    val keyData = cursor.getString(cursor.getColumnIndexOrThrow(KeysTableColumns.KEY_DATA))
                     var fileType: String? = null
 
                     try {

--- a/src/main/java/au/id/micolous/metrodroid/key/CardKeysDB.kt
+++ b/src/main/java/au/id/micolous/metrodroid/key/CardKeysDB.kt
@@ -17,11 +17,11 @@ class CardKeysDB (private val context: Context): CardKeysRetriever {
 
         // Static key requests should give all of the static keys.
         while (cursor.moveToNext()) {
-            if (cursor.getString(cursor.getColumnIndex(KeysTableColumns.CARD_TYPE)) != CardKeys.TYPE_MFC_STATIC)
+            if (cursor.getString(cursor.getColumnIndexOrThrow(KeysTableColumns.CARD_TYPE)) != CardKeys.TYPE_MFC_STATIC)
                 continue
             try {
-                val id = cursor.getInt(cursor.getColumnIndex(KeysTableColumns._ID))
-                val json = CardSerializer.jsonPlainStable.parseToJsonElement(cursor.getString(cursor.getColumnIndex(KeysTableColumns.KEY_DATA)))
+                val id = cursor.getInt(cursor.getColumnIndexOrThrow(KeysTableColumns._ID))
+                val json = CardSerializer.jsonPlainStable.parseToJsonElement(cursor.getString(cursor.getColumnIndexOrThrow(KeysTableColumns.KEY_DATA)))
                 val nk = ClassicStaticKeys.fromJSON(json.jsonObject, "cursor/$id") ?: continue
                 if (keys == null)
                     keys = nk
@@ -58,7 +58,7 @@ class CardKeysDB (private val context: Context): CardKeysRetriever {
         if (!cursor.moveToFirst())
             return null
         return CardKeys.fromJSON(
-                CardSerializer.jsonPlainStable.parseToJsonElement(cursor.getString(cursor.getColumnIndex(KeysTableColumns.KEY_DATA))).jsonObject,
-                cursor.getString(cursor.getColumnIndex(KeysTableColumns.CARD_TYPE)))
+                CardSerializer.jsonPlainStable.parseToJsonElement(cursor.getString(cursor.getColumnIndexOrThrow(KeysTableColumns.KEY_DATA))).jsonObject,
+                cursor.getString(cursor.getColumnIndexOrThrow(KeysTableColumns.CARD_TYPE)))
     }
 }

--- a/src/main/java/au/id/micolous/metrodroid/util/ExportHelper.kt
+++ b/src/main/java/au/id/micolous/metrodroid/util/ExportHelper.kt
@@ -55,9 +55,9 @@ object ExportHelper {
 
     @NonNls
     private fun strongHash(cursor: Cursor): String {
-        @NonNls val serial = cursor.getString(cursor.getColumnIndex(CardsTableColumns.TAG_SERIAL)).trim { it <= ' ' }
+        @NonNls val serial = cursor.getString(cursor.getColumnIndexOrThrow(CardsTableColumns.TAG_SERIAL)).trim { it <= ' ' }
         @NonNls val data = XmlUtils.cutXmlDef(
-                cursor.getString(cursor.getColumnIndex(CardsTableColumns.DATA)).trim { it <= ' ' })
+                cursor.getString(cursor.getColumnIndexOrThrow(CardsTableColumns.DATA)).trim { it <= ' ' })
         val md = MessageDigest.getInstance("SHA-512")
 
         md.update(("(${serial.length}, ${data.length})").toByteArray(Charsets.UTF_8))
@@ -76,7 +76,7 @@ object ExportHelper {
             @NonNls val hash = strongHash(cursor)
 
             if (hash in hashes) {
-                res.add(cursor.getLong(cursor.getColumnIndex(CardsTableColumns._ID)))
+                res.add(cursor.getLong(cursor.getColumnIndexOrThrow(CardsTableColumns._ID)))
                 continue
             }
 
@@ -118,9 +118,9 @@ object ExportHelper {
                     Localizer.englishString(R.string.exported_at, now.isoDateTimeFormat()) + "\n" + Utils.deviceInfoStringEnglish)
 
         while (cursor.moveToNext()) {
-            val content = cursor.getString(cursor.getColumnIndex(CardsTableColumns.DATA)).trim { it <= ' ' }
-            val scannedAt = cursor.getLong(cursor.getColumnIndex(CardsTableColumns.SCANNED_AT))
-            val tagId = cursor.getString(cursor.getColumnIndex(CardsTableColumns.TAG_SERIAL))
+            val content = cursor.getString(cursor.getColumnIndexOrThrow(CardsTableColumns.DATA)).trim { it <= ' ' }
+            val scannedAt = cursor.getLong(cursor.getColumnIndexOrThrow(CardsTableColumns.SCANNED_AT))
+            val tagId = cursor.getString(cursor.getColumnIndexOrThrow(CardsTableColumns.TAG_SERIAL))
             val scannedAtTs = TimestampFull(scannedAt, MetroTimeZone.LOCAL)
             val ext = if (content[0] == '<') "xml" else "json"
             var name: String


### PR DESCRIPTION
When there is no column we will get a throw anyway. Getting a throw earlier is
a benefit for debugging. But we should never get into this situation as we
control our DB