### PR TITLE
NodeWrapperImpl: work on String rather than InputStream

### DIFF
--- a/src/jvmCommonMain/kotlin/au/id/micolous/metrodroid/serializers/NodeWrapperImpl.kt
+++ b/src/jvmCommonMain/kotlin/au/id/micolous/metrodroid/serializers/NodeWrapperImpl.kt
@@ -3,7 +3,6 @@ package au.id.micolous.metrodroid.serializers
 import au.id.micolous.metrodroid.card.Card
 import org.w3c.dom.Node
 import java.io.ByteArrayInputStream
-import java.io.InputStream
 import javax.xml.parsers.DocumentBuilderFactory
 
 class NodeWrapperImpl(private val node: Node): NodeWrapper {
@@ -23,16 +22,17 @@ class NodeWrapperImpl(private val node: Node): NodeWrapper {
         get() = node.nodeValue ?: node.textContent
 
     companion object {
-        fun read(stream: InputStream): NodeWrapper {
+        @OptIn(ExperimentalStdlibApi::class)
+        fun read(contents: String): NodeWrapper {
             val dbFactory = DocumentBuilderFactory.newInstance()
             val dBuilder = dbFactory.newDocumentBuilder()
             val doc = dBuilder.parse(
                 ByteArrayInputStream(
-                    filterBadXMLChars(stream.bufferedReader().readText()).encodeToByteArray())
+                    filterBadXMLChars(contents).encodeToByteArray())
             )
             return NodeWrapperImpl(doc.documentElement)
         }
     }
 }
 
-fun readCardXML(reader: InputStream): Card = readCardXML(NodeWrapperImpl.read(reader))
+fun readCardXML(contents: String): Card = readCardXML(NodeWrapperImpl.read(contents))

--- a/src/jvmCommonMain/kotlin/au/id/micolous/metrodroid/serializers/XmlPullParserIterator.kt
+++ b/src/jvmCommonMain/kotlin/au/id/micolous/metrodroid/serializers/XmlPullParserIterator.kt
@@ -30,12 +30,12 @@ object XmlPullFactory {
     fun newSerializer(): XmlSerializer = factory!!.newSerializer()
 }
 
-internal fun iterateXmlCards(stream: InputStream, iter: (String) -> Card?): Iterator<Card> {
+internal fun readXmlCards(stream: InputStream): Iterator<Card> {
     val xpp = XmlPullFactory.newPullParser()
     val reader = stream.reader(Charsets.UTF_8)
     xpp.setInput(reader)
 
-    return IteratorTransformerNotNull(XmlPullParserIterator(xpp), iter)
+    return IteratorTransformerNotNull(XmlPullParserIterator(xpp)) { readCardXML(it) }
 }
 
 private class XmlPullParserIterator(


### PR DESCRIPTION
All callers derive InputStream as ByteArrayInputStream from a String.
Let's reduce back-and-forth between String (UTF-16) and ByteArray(UTF-8).