### PR TITLE
orca: Handle hand-held readers better (fixes #681)

### DIFF
--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/orca/OrcaTransitData.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/orca/OrcaTransitData.kt
@@ -62,7 +62,7 @@ class OrcaTransitData (private val mSerialNumber: Int?,
 
         private fun parseTrips(card: DesfireCard, fileId: Int, isTopup: Boolean): List<TransactionTripAbstract> {
             val file = card.getApplication(APP_ID)?.getFile(fileId) as? RecordDesfireFile ?: return emptyList()
-            val useLog = file.records.map { OrcaTransaction(it, isTopup) }
+            val useLog = file.records.mapIndexed { i, d -> OrcaTransaction(d, isTopup, fileId, i) }
             return TransactionTrip.merge(useLog)
         }
 


### PR DESCRIPTION
Both Seattle Monorail and Water Taxis use KCM's agency ID and hand-held readers, and vehicle number 3.  We previously marked these as Monorail, but the Water Taxi also uses vehicle Number 3. 😞 

We don't have enough info to be able to tell these apart, so for now we'll mark these all as "point of sale", and show the `mCoachNum` as the "Machine ID" (though this will probably always be 3).

While here, I added the `file` and `rec` IDs to the "raw data" fields. This makes debugging much easier.

Tested this with a dump provided by @phcoder with a Water Taxi trip, shown below (with raw mode on):

![Screenshot_1656999743](https://user-images.githubusercontent.com/246847/177257990-ce665ca4-5429-4dfd-8f68-d861df3522bd.png)

This should let us close #681.

cc: @cookieguru, @frozenpandaman 