### PR TITLE
OV-Chipkaart: New subscriptions and a new operator

### DIFF
--- a/extra/mdst/tsv2pb-ovc.py
+++ b/extra/mdst/tsv2pb-ovc.py
@@ -48,7 +48,9 @@ OVC_OPERATORS = {
 
   0x0C: 'DUO', # Dienst Uitvoering Onderwijs
   0x19: 'Reseller', # used by Albert Heijn, Primera and Hermes busses and maybe even more
-  0x2C: 'DUO'
+  0x2C: 'DUO',
+
+  0x2711: 'GVB Flex'
 }
 
 lines = {}

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/ovc/OVChipTransaction.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/ovc/OVChipTransaction.kt
@@ -128,6 +128,7 @@ data class OVChipTransaction(override val parsed: En1545Parsed) : En1545Transact
         private const val AGENCY_ARRIVA = 0x08
         private const val AGENCY_DUO = 0x0C    // Could also be 2C though... ( http://www.ov-chipkaart.me/forum/viewtopic.php?f=10&t=299 )
         private const val AGENCY_STORE = 0x19
+        private const val AGENCY_GVB_FLEX = 0x2711
 
         const val TRANSACTION_TYPE = "TransactionType"
 

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/ovc/OvcLookup.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/ovc/OvcLookup.kt
@@ -44,10 +44,14 @@ object OvcLookup : En1545LookupSTR(OVCHIP_STR) {
         0x00e5 to R.string.ovc_sub_reizen_op_saldo_tijdelijk_eerste_klas,
         0x00e6 to R.string.ovc_sub_reizen_op_saldo_tijdelijk_tweede_klas,
         0x00e7 to R.string.ovc_sub_reizen_op_saldo_tijdelijk_eerste_klas_korting,
+        0x0226 to R.string.ovc_sub_reizen_op_rekening_trein,
+        0x0227 to R.string.ovc_sub_reizen_op_rekening_bus_tram_metro,
         /* Arriva */
         0x059a to R.string.ovc_sub_dalkorting,
         /* Veolia */
         0x0626 to R.string.ovc_sub_dalu_dalkorting,
+        /* GVB */
+        0x0675 to R.string.ovc_sub_gvb_nachtbus_saldo,
         /* Connexxion */
         0x0692 to R.string.ovc_sub_daluren_oost_nederland,
         0x069c to R.string.ovc_sub_daluren_oost_nederland,
@@ -56,6 +60,6 @@ object OvcLookup : En1545LookupSTR(OVCHIP_STR) {
         0x09c7 to R.string.ovc_sub_student_week_korting,
         0x09c9 to R.string.ovc_sub_student_week_vrij,
         0x09ca to R.string.ovc_sub_student_weekend_korting,
-        /* GVB */
+        /* GVB (continued) */
         0x0bbd to R.string.ovc_sub_fietssupplement)
 }

--- a/src/main/res/values-nl/strings.xml
+++ b/src/main/res/values-nl/strings.xml
@@ -1029,6 +1029,8 @@
     <string name="ovc_sub_reizen_op_saldo_tijdelijk_eerste_klas">Reizen op saldo (2-1 Dag)</string>
     <string name="ovc_sub_reizen_op_saldo_tijdelijk_tweede_klas">Reizen op saldo (1-2 Dag)</string>
     <string name="ovc_sub_reizen_op_saldo_tijdelijk_eerste_klas_korting">Reizen op saldo (2-1 Dag met korting)</string>
+    <string name="ovc_sub_reizen_op_rekening_trein">Reizen op Rekening Trein</string>
+    <string name="ovc_sub_reizen_op_rekening_bus_tram_metro">Reizen op Rekening Bus Tram Metro</string>
     <string name="ovc_sub_dalkorting">Dal Korting</string>
     <string name="ovc_sub_daluren_oost_nederland">Dal Voordeel Oost</string>
     <string name="ovc_sub_student_weekend_vrij">Student weekend-vrij</string>
@@ -1036,6 +1038,7 @@
     <string name="ovc_sub_student_week_vrij">Student week-vrij</string>
     <string name="ovc_sub_student_weekend_korting">Student weekend-korting</string>
     <string name="ovc_sub_fietssupplement">OV-fietsabonnement</string>
+    <string name="ovc_sub_gvb_nachtbus_saldo">GVB Nachtbus Saldo</string>
     <string name="ovc_sub_dalu_dalkorting">DALU Dalkorting</string>
     <string name="ovc_sub_studenten_ov_chipkaart_week_2009">Studenten ov-chipkaart week (2009)</string>
     <string name="ovc_sub_studenten_ov_chipkaart_weekend_2009">Studenten ov-chipkaart weekend (2009)</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1476,6 +1476,11 @@
     <string name="ovc_sub_reizen_op_saldo_tijdelijk_tweede_klas">Travel on Credit (1-2 Day)</string>
     <!-- Translators: Dutch "Reizen op saldo (2-1 Dag met korting)" -->
     <string name="ovc_sub_reizen_op_saldo_tijdelijk_eerste_klas_korting">Travel on Credit (2-1 Discount)</string>
+    <!-- Translators: Dutch "Reizen op Rekening Trein" -->
+    <string name="ovc_sub_reizen_op_rekening_trein">Travel via monthly bill (Train)</string>
+    <!-- Translators: Dutch "Reizen op Rekening Bus Tram Metro" -->
+    <string name="ovc_sub_reizen_op_rekening_bus_tram_metro">Travel via monthly bill (Bus/Tram/Metro)</string>
+
     <!--  Arriva -->
     <!-- Translators: Dutch "Dal Korting" -->
     <string name="ovc_sub_dalkorting">Dal Korting</string>
@@ -1494,6 +1499,8 @@
     <!-- GVB -->
     <!-- Translators: Dutch "OV-fietsabonnement" -->
     <string name="ovc_sub_fietssupplement">OV-fiets Season Ticket</string>
+    <!-- Translators: Dutch "GVB Nachtbus Saldo" -->
+    <string name="ovc_sub_gvb_nachtbus_saldo">Travel on credit (night bus)</string>
     <!-- Defunct cards. They are no longer used but may still show up on old cards -->
     <!-- Translators: Dutch "DALU Dalkorting" -->
     <string name="ovc_sub_dalu_dalkorting">DALU Dalkorting</string>


### PR DESCRIPTION
Hi there! This PR adds support for a few new subscription types and a new operator for the OV-Chipkaart, used in the Netherlands.

The original subscription names in Dutch (as generated by a printout from a GVB ticketing machine) are included, as well as my attempt at reasonable English translations.

Thanks to [techwolf12](https://github.com/techwolf12) for his help in deciphering these.