### PR TITLE
Update Leapcard API URL

### DIFF
--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/tfi_leap/LeapUnlocker.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/tfi_leap/LeapUnlocker.kt
@@ -238,7 +238,7 @@ class LeapUnlocker private constructor(private val mApplicationId: Int,
     }
 
     companion object {
-        private const val LEAP_API_URL = "https://tnfc.leapcard.ie//ReadCard/V0"
+        private const val LEAP_API_URL = "https://tnfc.leaptopup.com/ReadCard/V0"
         private const val TAG = "LeapUnlocker"
 
         @OptIn(ExperimentalSerializationApi::class)


### PR DESCRIPTION
Update Leapcard API URL

Current URL no longer works - it points to the same API but certificate does not include tnfc.leapcard.ie and as expected unlocking does not work. With this URL I was once again able to unlock Leapcards.