### PR TITLE
OV-Chipkaart: Create fake tagOn for busses that replace them

### DIFF
--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/ovc/OVChipTransaction.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/ovc/OVChipTransaction.kt
@@ -112,10 +112,12 @@ data class OVChipTransaction(override val parsed: En1545Parsed) : En1545Transact
         }
     }
 
+    val tripLength get() = parsed.getIntOrZero("TripDurationMinutes")
+
     companion object {
         private const val PROCESS_PURCHASE = 0x00
-        private const val PROCESS_CHECKIN = 0x01
-        private const val PROCESS_CHECKOUT = 0x02
+        internal const val PROCESS_CHECKIN = 0x01
+        internal const val PROCESS_CHECKOUT = 0x02
         private const val PROCESS_TRANSFER = 0x06
         private const val PROCESS_BANNED = 0x07
         private const val PROCESS_CREDIT = -0x02

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/ovc/OVChipTransitData.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/ovc/OVChipTransitData.kt
@@ -32,6 +32,8 @@ import au.id.micolous.metrodroid.time.MetroTimeZone
 import au.id.micolous.metrodroid.time.Timestamp
 import au.id.micolous.metrodroid.transit.*
 import au.id.micolous.metrodroid.transit.en1545.*
+import au.id.micolous.metrodroid.transit.ovc.OVChipTransaction.Companion.PROCESS_CHECKIN
+import au.id.micolous.metrodroid.transit.ovc.OVChipTransaction.Companion.TRANSACTION_TYPE
 import au.id.micolous.metrodroid.ui.HeaderListItem
 import au.id.micolous.metrodroid.ui.ListItem
 import au.id.micolous.metrodroid.ui.ListItemInterface
@@ -144,9 +146,45 @@ data class OVChipTransitData(
                 else
                 // handle two consecutive (duplicate) logins, skip the first one
                     nextTransaction
-            }.values.toMutableList()
+            }.values.fakeTagOnTransactions().toMutableList()
 
             return TransactionTripLastPrice.merge(transactions)
+        }
+
+        /**
+         * Some busses delete the tapOn transaction
+         * and only store a tapOff transaction with a tripLength
+         * This function adds fake tapOn transactions for the Trip log to correlate
+         */
+        private fun Collection<OVChipTransaction>.fakeTagOnTransactions(): Collection<OVChipTransaction> {
+            var previous: OVChipTransaction? = null
+            val output = ArrayList<OVChipTransaction>(this.size)
+            for (it in this.sortedBy { it.id }) {
+                if (previous != null) {
+                    if (it.isTapOff && it.tripLength > 0 && it.id - previous.id > 1) {
+                        // create a fake tagOn event
+                        val newParsed = En1545Parsed()
+                        for (field in listOf(   // copy some fields from the tagOff event
+                            En1545Transaction.EVENT_SERVICE_PROVIDER,
+                            En1545Transaction.EVENT_VEHICLE_ID,
+                        )) {
+                            newParsed.insertInt(field, "", it.parsed.getIntOrZero(field))
+                        }
+                        var date = it.parsed.getIntOrZero(En1545FixedInteger.dateName(En1545Transaction.EVENT))
+                        var time = it.parsed.getIntOrZero(En1545FixedInteger.timeLocalName(En1545Transaction.EVENT))
+                        time -= it.tripLength
+                        if (time < 0) { date -= 1; time += 1440 }
+                        newParsed.insertInt(TRANSACTION_TYPE, "", PROCESS_CHECKIN)
+                        newParsed.insertInt(En1545Transaction.EVENT_SERIAL_NUMBER, "", it.id-1)
+                        newParsed.insertInt(En1545FixedInteger.dateName(En1545Transaction.EVENT), "", date)
+                        newParsed.insertInt(En1545FixedInteger.timeLocalName(En1545Transaction.EVENT), "", time)
+                        output.add(OVChipTransaction(newParsed))
+                    }
+                }
+                output.add(it)
+                previous = it
+            }
+            return output
         }
 
         fun<T: En1545Subscription> getSubscriptions(card: ClassicCard, index: OVChipIndex,  factory: (data: ImmutableByteArray, type1: Int, used: Int) -> T): List<T> {


### PR DESCRIPTION
For some reason, several of my bus transactions are missing tagOn events entirely, with a clear gap in the transaction IDs, and instead they left a tagOff event with a Trip Duration field. While it's very nice of them to help use the 28 transactions sparingly, the TripTransaction correlation would appreciate having a tagOn event to show the trip length in the trip log.
So, this change inserts fake tagOn events starting at the right time before the tagOff event.

This will conflict with my other PRs, I'm prepared to update things as changes are requested and things are merged! <3