### PR TITLE
Sort Clipper trips by timestamp

### DIFF
--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/clipper/ClipperTransitData.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/clipper/ClipperTransitData.kt
@@ -96,7 +96,7 @@ class ClipperTransitData (private val mSerialNumber: Long?,
                 result.add(trip)
                 pos -= RECORD_LENGTH
             }
-            return result
+            return result.sortedBy { it.startTimestamp?.timeInMillis }
         }
 
         private fun parseRefills(card: DesfireCard): List<ClipperRefill> {
@@ -108,7 +108,8 @@ class ClipperTransitData (private val mSerialNumber: Long?,
             val data = card.getApplication(APP_ID)?.getFile(0x04)?.data ?: return emptyList()
             return (data.indices step RECORD_LENGTH).reversed().
                     map { pos -> data.sliceOffLen(pos, RECORD_LENGTH) }.
-                    mapNotNull { slice -> createRefill(slice) }
+                    mapNotNull { slice -> createRefill(slice) }.
+                    sortedBy { it.startTimestamp?.timeInMillis }
         }
 
         private fun createRefill(useData: ImmutableByteArray): ClipperRefill? {

--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/clipper/ClipperTrip.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/clipper/ClipperTrip.kt
@@ -28,7 +28,7 @@ package au.id.micolous.metrodroid.transit.clipper
 import au.id.micolous.metrodroid.multi.FormattedString
 import au.id.micolous.metrodroid.multi.Parcelize
 
-import au.id.micolous.metrodroid.time.Timestamp
+import au.id.micolous.metrodroid.time.TimestampFull
 import au.id.micolous.metrodroid.transit.Station
 import au.id.micolous.metrodroid.transit.TransitCurrency
 import au.id.micolous.metrodroid.transit.Trip
@@ -46,10 +46,10 @@ class ClipperTrip (private val mTimestamp: Long,
                    private val mVehicleNum: Int,
                    private val mTransportCode: Int): Trip() {
 
-    override val startTimestamp: Timestamp?
+    override val startTimestamp: TimestampFull?
         get() = ClipperTransitData.clipperTimestampToCalendar(mTimestamp)
 
-    override val endTimestamp: Timestamp?
+    override val endTimestamp: TimestampFull?
         get() = ClipperTransitData.clipperTimestampToCalendar(mExitTimestamp)
 
     // Bus doesn't record line


### PR DESCRIPTION
My Clipper card seems to have trips sorted incorrectly, perhaps from using it for so many years