### PR TITLE
Update some Caltrain and Muni mode icons

### DIFF
--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/clipper/ClipperTrip.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/clipper/ClipperTrip.kt
@@ -91,6 +91,8 @@ class ClipperTrip (private val mTimestamp: Long,
             0x6f -> Mode.METRO
             0x61, 0x75 -> Mode.BUS
             0x73 -> Mode.FERRY
+            0x77 -> Mode.BUS      // seen for Muni bus
+            0x78 -> Mode.TRAIN     // might also be like 0x62
             else -> Mode.OTHER
         }
 


### PR DESCRIPTION
My Clipper card has a few different transit codes for Caltrain and Munin rides