### PR TITLE
fix TUNION card reader by adding sfi file as fallback

### DIFF
--- a/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/china/ChinaTransitData.kt
+++ b/src/commonMain/kotlin/au/id/micolous/metrodroid/transit/china/ChinaTransitData.kt
@@ -47,9 +47,11 @@ object ChinaTransitData {
     // upper bit is some garbage
     fun parseBalance(card: ChinaCard): Int? = card.getBalance(0)?.getBitsFromBufferSigned(1, 31)
 
-    fun getFile(card: ChinaCard, id: Int): ISO7816File? {
-        val f = card.getFile(ISO7816Selector.makeSelector(0x1001, id))
-        return f ?: card.getFile(ISO7816Selector.makeSelector(id))
+    fun getFile(card: ChinaCard, id: Int, trySfi: Boolean = true): ISO7816File? {
+        val f = card.getFile(ISO7816Selector.makeSelector(0x1001, id)) ?: card.getFile(ISO7816Selector.makeSelector(id))
+        if (f != null)
+            return f
+        return if (!trySfi) null else card.getSfiFile(id)
     }
 
     fun parseHexDate(value: Int?): Timestamp? {


### PR DESCRIPTION
With 2 known working TUNION cards(one known working on an older version of metrodroid), the latest code only recognizes SFI files(ISO7816), which are sufficient to retrieve card info. Old reader code will somehow generate some duplicated standard file data entries, so it wasn't broken.

This patch add SFI file as fallback to fix TUNION reader on latest version. I didn't replace everything because I only have TUNION cards to verify while multiple card variants share the same code.